### PR TITLE
feat: add collaborator EPK discovery and modernize Saved page filters

### DIFF
--- a/client/src/api/epks.js
+++ b/client/src/api/epks.js
@@ -225,6 +225,11 @@ export const setBannerThumbnail = async (epkId, bannerId) => {
   }
 };
 
+export const getMyCollaborations = (token) =>
+  axios.get(`${process.env.REACT_APP_BACKEND_URL}/fepks/collaborations/mine`, {
+    headers: { Authorization: `Bearer ${token}` },
+  }).then((r) => r.data);
+
 export const listCollaborators = (epkId, token) =>
   axios.get(`${process.env.REACT_APP_BACKEND_URL}/fepks/${epkId}/collaborators`, {
     headers: { Authorization: `Bearer ${token}` },

--- a/client/src/components/Filter/DropDown.css
+++ b/client/src/components/Filter/DropDown.css
@@ -10,29 +10,30 @@
   top: 100%;
   left: 0;
   z-index: 999;
-  /* display: block; */
-  border: 1px solid #ccc;
+  border: 1px solid #e5e7eb;
   background-color: white;
   border-radius: 8px;
-  border: 1px solid #e5e7eb;
   width: max-content;
   box-shadow: 0px 10px 25px rgba(0,0,0,0.15);
   overflow: hidden;
+}
+
+.filter-button-container.align-right .dropdown-content {
+  left: auto;
+  right: 0;
+}
+
+@media (max-width: 640px) {
+  .filter-button-container.align-right .dropdown-content {
+    left: 0;
+    right: auto;
+  }
 }
 
 .dropdown-content .dropdown-option {
   background-color: white;
   color: #1e0039;
 }
-
-/* .dropdown-content {
-  display: none;
-  position: absolute;
-  background-color: #f9f9f9;
-  min-width: 160px;
-  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
-  z-index: 1;
-} */
 
 .dropdown-content button {
   padding: 8px 16px;

--- a/client/src/components/Filter/FilterWrapper.js
+++ b/client/src/components/Filter/FilterWrapper.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 
-const FilterWrapper = ({ label, children, selectedValue, className }) => {
+const FilterWrapper = ({ label, children, selectedValue, className, align }) => {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef(null);
 
@@ -24,7 +24,7 @@ const FilterWrapper = ({ label, children, selectedValue, className }) => {
   }, []);
 
   return (
-    <div className={`filter-button-container ${className || ""}`} ref={containerRef}>
+    <div className={`filter-button-container ${align === "right" ? "align-right" : ""} ${className || ""}`} ref={containerRef}>
         <button
             className={`tw-px-4 tw-h-7 tw-rounded-lg tw-text-xs tw-transition-colors ${
                 selectedValue && selectedValue !== "All"

--- a/client/src/pages/Dashboard/SavedPage.js
+++ b/client/src/pages/Dashboard/SavedPage.js
@@ -67,7 +67,7 @@ export default function SavedPage() {
         .then((res) => setCollaborationList(res))
         .catch((err) => console.error("Collaborations fetch error:", err));
     }
-  }, [userId]);
+  }, [userId, user?.token]);
 
   useEffect(() => {
     if (itemFilter === 0) {

--- a/client/src/pages/Dashboard/SavedPage.js
+++ b/client/src/pages/Dashboard/SavedPage.js
@@ -3,14 +3,9 @@ import { useSelector } from "react-redux";
 import Sidebar from "../../components/Dashboard/Sidebar";
 import LoadingSpin from "../../components/Dashboard/LoadingSpin";
 import http from "../../http-common";
+import { getMyCollaborations } from "../../api/epks";
 import { useTranslation } from "react-i18next";
 
-import StarMidnightIcon from "../../images/icons/StarMidnight.svg";
-import StarWhiteIcon from "../../images/icons/StarFULL.svg";
-import PlusIcon from "../../images/icons/PlusEmpty.svg";
-import PlusWhiteIcon from "../../images/icons/PlusFULL.svg";
-import DollarIcon from "../../images/icons/DollarEmpty.svg";
-import DollarWhiteIcon from "../../images/icons/DollarFull.svg";
 import moviePic from "../../images/movie11.jpg";
 
 import GenderDropdown from "../../components/Filter/GenderDropdown";
@@ -31,6 +26,7 @@ export default function SavedPage() {
   const [actorStarredList, setActorStarredList] = useState([]);
   const [filteredEpkList, setFilteredEpkList] = useState([]);
   const [filteredActorList, setFilteredActorList] = useState([]);
+  const [collaborationList, setCollaborationList] = useState([]);
   const [loading, setLoading] = useState(true);
   const [productionFilter, setProductionFilter] = useState(0);
   const [itemFilter, setItemFilter] = useState(0); // 0: EPK, 1: Actor
@@ -44,7 +40,7 @@ export default function SavedPage() {
   
   useEffect(() => {
     if (userId === "0") return;
-    
+
     setLoading(true);
     Promise.all([
       http.get(`/fepks/getStarredFepksByUser/${userId}`),
@@ -65,6 +61,12 @@ export default function SavedPage() {
         console.error("Fetch Error:", err);
         setLoading(false);
       });
+
+    if (user?.token) {
+      getMyCollaborations(user.token)
+        .then((res) => setCollaborationList(res))
+        .catch((err) => console.error("Collaborations fetch error:", err));
+    }
   }, [userId]);
 
   useEffect(() => {
@@ -126,6 +128,9 @@ export default function SavedPage() {
     setEthnicityLabel(label);
   };
 
+  const selectClass =
+    "tw-w-full tw-rounded-lg tw-border tw-border-[#1E0039] tw-bg-white tw-px-3 tw-py-2 tw-text-sm tw-text-[#1E0039] tw-cursor-pointer focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-[#6627a7]";
+
   return (
     <div className="tw-flex tw-h-screen tw-flex-col tw-overflow-hidden tw-bg-[#1E0039]">
       <div className="tw-mb-8 tw-mt-24 tw-flex tw-justify-start tw-pl-24 tw-text-white">
@@ -140,129 +145,150 @@ export default function SavedPage() {
         </div>
 
         <div className="tw-scrollbar-w-36 tw-mx-auto tw-mt-12 tw-h-5/6 tw-w-5/6 tw-overflow-auto tw-rounded-lg tw-bg-white tw-p-6 md:tw-ml-16">
-          <div className="tw-flex tw-h-1/6 tw-w-full tw-flex-col tw-items-center tw-justify-center">
-            <div className="tw-flex tw-w-full tw-justify-between">
-              <div className="tw-flex tw-h-9 tw-w-2/5 tw-items-center tw-justify-start tw-pl-2 tw-text-sm tw-text-[#1E0039] md:tw-text-base">
-                {itemFilter === 0 ? "Find all the film EPKs you've saved here." : "Find all the actors you've saved here."}
-              </div>
-              <div className="tw-flex tw-h-9 tw-w-3/5 tw-items-center tw-justify-center tw-shadow-[3px_5px_10px_1px_rgba(30,0,57,0.8)]">
-                <div
-                  className={(itemFilter === 0 ? "tw-w-2/3 tw-bg-[#1E0039] tw-text-white" : "tw-w-1/3 tw-bg-white tw-text-[#1E0039]") + " tw-flex tw-h-full tw-items-center tw-justify-center hover:tw-cursor-pointer"}
-                  onClick={() => handleItemBtnClick(0)}
-                >
-                  Film EPKs
-                </div>
-                <div
-                  className={(itemFilter === 1 ? "tw-w-2/3 tw-bg-[#1E0039] tw-text-white" : "tw-w-1/3 tw-bg-white tw-text-[#1E0039]") + " tw-flex tw-h-full tw-items-center tw-justify-center hover:tw-cursor-pointer"}
-                  onClick={() => handleItemBtnClick(1)}
-                >
-                  Actors
-                </div>
-              </div>
+          {/* Header row: description + item toggle */}
+          <div className="tw-mb-4 tw-flex tw-flex-col tw-gap-4 sm:tw-flex-row sm:tw-items-center sm:tw-justify-between">
+            <p className="tw-text-sm tw-text-gray-500">
+              {itemFilter === 0 ? t("Find all the film EPKs you've saved here.") : itemFilter === 1 ? t("Find all the actors you've saved here.") : t("EPKs you've been invited to collaborate on.")}
+            </p>
+            <div className="tw-flex tw-gap-1 tw-rounded-xl tw-bg-gray-100 tw-p-1">
+              <button
+                onClick={() => handleItemBtnClick(0)}
+                className={`tw-rounded-lg tw-px-4 tw-py-1.5 tw-text-sm tw-font-medium tw-transition-colors ${itemFilter === 0 ? "tw-bg-[#1E0039] tw-text-white tw-shadow" : "tw-text-gray-500 hover:tw-text-[#1E0039]"}`}
+              >
+                {t("Film EPKs")}
+              </button>
+              <button
+                onClick={() => handleItemBtnClick(1)}
+                className={`tw-rounded-lg tw-px-4 tw-py-1.5 tw-text-sm tw-font-medium tw-transition-colors ${itemFilter === 1 ? "tw-bg-[#1E0039] tw-text-white tw-shadow" : "tw-text-gray-500 hover:tw-text-[#1E0039]"}`}
+              >
+                {t("Actors")}
+              </button>
+              <button
+                onClick={() => handleItemBtnClick(2)}
+                className={`tw-rounded-lg tw-px-4 tw-py-1.5 tw-text-sm tw-font-medium tw-transition-colors ${itemFilter === 2 ? "tw-bg-[#1E0039] tw-text-white tw-shadow" : "tw-text-gray-500 hover:tw-text-[#1E0039]"}`}
+              >
+                {t("Shared with me")}
+              </button>
             </div>
-
-            {itemFilter === 0 ? (
-              <div className="tw-mt-4 tw-flex tw-w-full tw-flex-col tw-justify-between md:tw-flex-row">
-                <div className="md:tw-w-3/6">
-                  <div className="tw-mb-2 tw-flex tw-h-7 tw-justify-between tw-rounded-xl tw-bg-white tw-px-4 tw-text-xs tw-shadow-[3px_5px_10px_1px_rgba(30,0,57,0.8)]">
-                    <button className={(typeFilter === 0 ? "tw-bg-[#6627a7] tw-text-white" : "tw-bg-white") + " tw-rounded-lg tw-px-2"} onClick={() => handleNumBtnClick(0)}>{t("All")}</button>
-                    <button className={(typeFilter === 1 ? "tw-bg-[#6627a7] tw-text-white" : "tw-bg-white") + " tw-rounded-lg tw-px-2"} onClick={() => handleNumBtnClick(1)}>
-                      <img src={typeFilter === 1 ? StarWhiteIcon : StarMidnightIcon} alt="Star" style={{ width: 22, height: 22 }} />
-                    </button>
-                    <button className={(typeFilter === 2 ? "tw-bg-[#6627a7] tw-text-white" : "tw-bg-white") + " tw-rounded-lg tw-px-2"} onClick={() => handleNumBtnClick(2)}>
-                      <img src={typeFilter === 2 ? PlusWhiteIcon : PlusIcon} alt="Plus" style={{ width: 20, height: 20 }} />
-                    </button>
-                    <button className={(typeFilter === 3 ? "tw-bg-[#6627a7] tw-text-white" : "tw-bg-white") + " tw-rounded-lg tw-px-2"} onClick={() => handleNumBtnClick(3)}>
-                      <img src={typeFilter === 3 ? DollarWhiteIcon : DollarIcon} alt="Dollar" style={{ width: 18, height: 18 }} />
-                    </button>
-                  </div>
-                </div>
-                <div className="md:tw-w-3/6">
-                  <div className="tw-mb-2 tw-flex tw-h-7 tw-justify-between tw-rounded-xl tw-bg-white tw-px-4 tw-text-xs tw-shadow-[3px_5px_10px_1px_rgba(30,0,57,0.8)] md:tw-ml-6">
-                    <button className={(productionFilter === 0 ? "tw-bg-[#6627a7] tw-text-white" : "tw-bg-white") + " tw-rounded-lg tw-px-2"} onClick={() => handleBtnClick(0)}>{t("All")}</button>
-                    <button className={(productionFilter === 1 ? "tw-bg-[#6627a7] tw-text-white" : "tw-bg-white") + " tw-rounded-lg tw-px-2"} onClick={() => handleBtnClick(1)}>{t("Pre-Production")}</button>
-                    <button className={(productionFilter === 2 ? "tw-bg-[#6627a7] tw-text-white" : "tw-bg-white") + " tw-rounded-lg tw-px-2"} onClick={() => handleBtnClick(2)}>{t("Production")}</button>
-                    <button className={(productionFilter === 3 ? "tw-bg-[#6627a7] tw-text-white" : "tw-bg-white") + " tw-rounded-lg tw-px-2"} onClick={() => handleBtnClick(3)}>{t("Post-Production")}</button>
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <div className="tw-mt-4 tw-flex tw-w-full tw-flex-col tw-justify-between md:tw-flex-row">
-                <div className="md:tw-w-3/6">
-                  <div className="tw-mb-2 tw-flex tw-h-7 tw-justify-between tw-rounded-xl tw-bg-white tw-px-4 tw-text-xs tw-shadow-[3px_5px_10px_1px_rgba(30,0,57,0.8)]">
-                    <button className={(typeFilter === 0 ? "tw-bg-[#6627a7] tw-text-white" : "tw-bg-white") + " tw-rounded-lg tw-px-2"} onClick={() => handleNumBtnClick(0)}>{t("All")}</button>
-                    <button className={(typeFilter === 1 ? "tw-bg-[#6627a7] tw-text-white" : "tw-bg-white") + " tw-rounded-lg tw-px-2"} onClick={() => handleNumBtnClick(1)}>
-                      <img src={typeFilter === 1 ? StarWhiteIcon : StarMidnightIcon} alt="Star" style={{ width: 22, height: 22 }} />
-                    </button>
-                    <button className={(typeFilter === 2 ? "tw-bg-[#6627a7] tw-text-white" : "tw-bg-white") + " tw-rounded-lg tw-px-2"} onClick={() => handleNumBtnClick(2)}>
-                      <img src={typeFilter === 2 ? PlusWhiteIcon : PlusIcon} alt="Plus" style={{ width: 20, height: 20 }} />
-                    </button>
-                    <button className="tw-opacity-0 tw-cursor-default" disabled><img src={DollarIcon} alt="Dollar" style={{ width: 18 }} /></button>
-                  </div>
-                </div>
-                <div className="md:tw-w-3/6">
-                  <div className="tw-mb-2 tw-flex tw-h-7 tw-justify-between tw-rounded-xl tw-bg-white tw-px-4 tw-text-xs tw-shadow-[3px_5px_10px_1px_rgba(30,0,57,0.8)] md:tw-ml-6">
-                    <button className={(selectedGender === "All" && selectedAgeRange === "All" && selectedEthnicity === "All" ? "tw-bg-[#6627a7] tw-text-white" : "tw-bg-white") + " tw-rounded-lg tw-px-2"} 
-                      onClick={() => { setSelectedGender("All"); setSelectedAgeRange("All"); setSelectedEthnicity("All"); setAgeLabel("All"); setEthnicityLabel("All"); }}>{t("All")}</button>
-                    <FilterWrapper label={t("Gender")} selectedValue={selectedGender}><GenderDropdown selectedValue={selectedGender} onOptionSelect={handleGenderSelect} /></FilterWrapper>
-                    <FilterWrapper label={t("Ethnicity")} selectedValue={ethnicityLabel !== "All" ? t("ethnicities." + ethnicityLabel) : "All"}><EthnicityDropdown selectedValue={selectedEthnicity} onOptionSelect={handleEthnicitySelect} /></FilterWrapper>
-                    <FilterWrapper label={t("Age")} selectedValue={ageLabel}><AgeRangeDropdown selectedValue={selectedAgeRange} onOptionSelect={handleAgeRangeSelect} /></FilterWrapper>
-                  </div>
-                </div>
-              </div>
-            )}
           </div>
 
+          {/* Filter row — hidden on Shared with me tab */}
+          {itemFilter === 2 ? null : itemFilter === 0 ? (
+            <div className="tw-mb-4 tw-flex tw-flex-col tw-gap-3 sm:tw-flex-row">
+              <select
+                value={typeFilter}
+                onChange={(e) => handleNumBtnClick(Number(e.target.value))}
+                className={selectClass}
+              >
+                <option value={0}>{t("All types")}</option>
+                <option value={1}>{t("Starred")}</option>
+                <option value={2}>{t("Following")}</option>
+                <option value={3}>{t("Wish to Buy")}</option>
+              </select>
+              <select
+                value={productionFilter}
+                onChange={(e) => handleBtnClick(Number(e.target.value))}
+                className={selectClass}
+              >
+                <option value={0}>{t("All stages")}</option>
+                <option value={1}>{t("Pre-Production")}</option>
+                <option value={2}>{t("Production")}</option>
+                <option value={3}>{t("Post-Production")}</option>
+              </select>
+            </div>
+          ) : (
+            <div className="tw-mb-4 tw-flex tw-flex-col tw-gap-3 sm:tw-flex-row sm:tw-items-center">
+              <select
+                value={typeFilter}
+                onChange={(e) => handleNumBtnClick(Number(e.target.value))}
+                className={selectClass}
+              >
+                <option value={0}>{t("All types")}</option>
+                <option value={1}>{t("Starred")}</option>
+                <option value={2}>{t("Following")}</option>
+              </select>
+              <FilterWrapper label={t("Gender")} selectedValue={selectedGender}>
+                <GenderDropdown selectedValue={selectedGender} onOptionSelect={handleGenderSelect} />
+              </FilterWrapper>
+              <FilterWrapper label={t("Ethnicity")} selectedValue={ethnicityLabel !== "All" ? t("ethnicities." + ethnicityLabel) : "All"} align="right">
+                <EthnicityDropdown selectedValue={selectedEthnicity} onOptionSelect={handleEthnicitySelect} />
+              </FilterWrapper>
+              <FilterWrapper label={t("Age")} selectedValue={ageLabel} align="right">
+                <AgeRangeDropdown selectedValue={selectedAgeRange} onOptionSelect={handleAgeRangeSelect} />
+              </FilterWrapper>
+              {(selectedGender !== "All" || selectedAgeRange !== "All" || selectedEthnicity !== "All") && (
+                <button
+                  onClick={() => { setSelectedGender("All"); setSelectedAgeRange("All"); setSelectedEthnicity("All"); setAgeLabel("All"); setEthnicityLabel("All"); }}
+                  className="tw-whitespace-nowrap tw-rounded-lg tw-border tw-border-gray-300 tw-px-3 tw-py-2 tw-text-sm tw-text-gray-500 hover:tw-border-[#1E0039] hover:tw-text-[#1E0039]"
+                >
+                  {t("Clear")}
+                </button>
+              )}
+            </div>
+          )}
          <div className="tw-mt-10 tw-h-5/6 tw-overflow-auto tw-rounded-lg tw-bg-gray-300 tw-p-4">
           {loading ? (
             <LoadingSpin />
           ) : (
             <>
-              {/* 1. HANDLE EMPTY STATES INLINE */}
-              {((itemFilter === 0 && filteredEpkList.length === 0) || 
-                (itemFilter === 1 && filteredActorList.length === 0)) ? (
-                <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-py-20">
-                  <p className="tw-text-2xl tw-font-light tw-text-gray-600">
-                    {itemFilter === 0 
-                      ? t("No EPKs found matching your search.") 
-                      : t("No Actors found matching your search.")}
-                  </p>
-                </div>
+              {itemFilter === 2 ? (
+                /* SHARED WITH ME */
+                collaborationList.length === 0 ? (
+                  <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-py-20">
+                    <p className="tw-text-2xl tw-font-light tw-text-gray-600">{t("No EPKs shared with you yet.")}</p>
+                  </div>
+                ) : (
+                  <div className="tw-grid tw-grid-cols-2 tw-gap-4 tw-p-2 md:tw-grid-cols-4 lg:tw-grid-cols-6 xl:tw-grid-cols-8">
+                    {collaborationList.map((epk) => {
+                      const imgSrc = epk.banner_url
+                        ? `${process.env.REACT_APP_AWS_URL}/${epk.banner_url}`
+                        : moviePic;
+                      return (
+                        <a key={epk._id} href={`/editFepk/${epk._id}`} className="tw-transition-transform hover:tw-scale-105">
+                          <img src={imgSrc} alt={epk.title} className="tw-aspect-square tw-w-full tw-rounded-lg tw-object-cover" />
+                          <p className="tw-mt-1 tw-truncate tw-text-center tw-text-xs tw-text-[#1E0039]">{epk.title}</p>
+                        </a>
+                      );
+                    })}
+                  </div>
+                )
               ) : (
-                /* 2. RENDER THE GRID */
-                <div className="tw-grid tw-grid-cols-2 tw-gap-4 tw-p-2 md:tw-grid-cols-4 lg:tw-grid-cols-6 xl:tw-grid-cols-8">
-                  {(itemFilter === 0 ? filteredEpkList : filteredActorList).map((item) => {
-                    const isEpk = itemFilter === 0;
-                    const linkPath = isEpk ? `/epk/${item._id}` : `/actor/${item._id}`;
-                    
-                    // Resolve Image URL
-                    const imgSrc = isEpk
-                      ? (item.banner_url ? `${process.env.REACT_APP_AWS_URL}/${item.banner_url}` : moviePic)
-                      : (item.picture?.startsWith("https") ? item.picture : `${process.env.REACT_APP_AWS_URL}/${item.picture}`);
-
-                    return (
-                      <a 
-                        key={item._id} 
-                        href={linkPath} 
-                        className="tw-transition-transform hover:tw-scale-105"
-                      >
-                        <img
-                          src={imgSrc}
-                          alt={isEpk ? item.title : `${item.firstName} ${item.lastName}`}
-                          className={`tw-aspect-square tw-w-full tw-object-cover ${isEpk ? "tw-rounded-lg" : "tw-rounded-3xl"}`}
-                        />
-                        
-                        {!isEpk && (
-                          <div className="tw-mt-1 tw-w-full tw-truncate tw-text-center">
-                            <p className="tw-text-sm tw-font-medium">
-                              {`${item.firstName} ${item.lastName}`}
-                            </p>
-                          </div>
-                        )}
-                      </a>
-                    );
-                  })}
-                </div>
+                <>
+                  {/* EMPTY STATE */}
+                  {((itemFilter === 0 && filteredEpkList.length === 0) ||
+                    (itemFilter === 1 && filteredActorList.length === 0)) ? (
+                    <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-py-20">
+                      <p className="tw-text-2xl tw-font-light tw-text-gray-600">
+                        {itemFilter === 0 ? t("No EPKs found matching your search.") : t("No Actors found matching your search.")}
+                      </p>
+                    </div>
+                  ) : (
+                    /* GRID */
+                    <div className="tw-grid tw-grid-cols-2 tw-gap-4 tw-p-2 md:tw-grid-cols-4 lg:tw-grid-cols-6 xl:tw-grid-cols-8">
+                      {(itemFilter === 0 ? filteredEpkList : filteredActorList).map((item) => {
+                        const isEpk = itemFilter === 0;
+                        const linkPath = isEpk ? `/epk/${item._id}` : `/actor/${item._id}`;
+                        const imgSrc = isEpk
+                          ? (item.banner_url ? `${process.env.REACT_APP_AWS_URL}/${item.banner_url}` : moviePic)
+                          : (item.picture?.startsWith("https") ? item.picture : `${process.env.REACT_APP_AWS_URL}/${item.picture}`);
+                        return (
+                          <a key={item._id} href={linkPath} className="tw-transition-transform hover:tw-scale-105">
+                            <img
+                              src={imgSrc}
+                              alt={isEpk ? item.title : `${item.firstName} ${item.lastName}`}
+                              className={`tw-aspect-square tw-w-full tw-object-cover ${isEpk ? "tw-rounded-lg" : "tw-rounded-3xl"}`}
+                            />
+                            {!isEpk && (
+                              <div className="tw-mt-1 tw-w-full tw-truncate tw-text-center">
+                                <p className="tw-text-sm tw-font-medium">{`${item.firstName} ${item.lastName}`}</p>
+                              </div>
+                            )}
+                          </a>
+                        );
+                      })}
+                    </div>
+                  )}
+                </>
               )}
             </>
           )}

--- a/server/controllers/fepk.js
+++ b/server/controllers/fepk.js
@@ -1170,6 +1170,20 @@ export const removeCollaborator = async (req, res) => {
   }
 };
 
+export const getMyCollaborations = async (req, res) => {
+  const userId = (req.user._id || req.user.id).toString();
+  try {
+    const fepks = await fepk
+      .find({ "collaborators.user": userId, deleted: false })
+      .select("title film_maker status production_type banners banner_url collaborators")
+      .populate("film_maker", "firstName lastName picture");
+
+    res.status(200).json(fepks);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
 export const listCollaborators = async (req, res) => {
   try {
     const epk = await fepk

--- a/server/models/fepk.js
+++ b/server/models/fepk.js
@@ -501,6 +501,8 @@ fepkSchema.post(['find', 'findOne'], function(docs) {
     ensureBackwardCompatibility(docs);
   }
 });
+fepkSchema.index({ "collaborators.user": 1 });
+
 const fepk = mongoose.model("fepk", fepkSchema);
 
 export default fepk;

--- a/server/routes/fepk.js
+++ b/server/routes/fepk.js
@@ -40,6 +40,7 @@ import {
   addCollaborator,
   removeCollaborator,
   listCollaborators,
+  getMyCollaborations,
 } from "../controllers/fepk.js";
 import { canEditEpk } from "../middleware/canEditEpk.js";
 import { authUser } from "../middleware/auth.js";
@@ -102,6 +103,9 @@ router.get("/favourite/:fepkid/:userid", getFepkFavourite);
 router.get("/sharing/:fepkid/:userid", getFepkSharings);
 router.get("/wishestodonate/:fepkid/:userid", getFepkWishedToDonate);
 router.get("/wishestobuy/:fepkid/:userid", getFepkWishedToBuy);
+
+// Get all FEPKs the authenticated user collaborates on
+router.get("/collaborations/mine", authUser, getMyCollaborations);
 
 // Collaborator management (owner only)
 router.get("/:epkId/collaborators", authUser, canEditEpk, listCollaborators);


### PR DESCRIPTION
## EPK collaborator access + saved page UI refresh

Adds a "Shared with me" tab so collaborators can find EPKs they've been invited to edit. Refreshes saved page filters with styled dropdowns and a pill-style segmented control.

---

### Files changed

**`server/models/fepk.js`**
- Added multikey index on `collaborators.user`

**`server/controllers/fepk.js`**
- Added `getMyCollaborations`: returns non-deleted EPKs where the user is a collaborator, card-view fields only

**`server/routes/fepk.js`**
- Added `GET /fepks/collaborations/mine`, auth-gated, placed before `/:id` wildcard

**`client/src/api/epks.js`**
- Added `getMyCollaborations(token)`

**`client/src/pages/Dashboard/SavedPage.js`**
- Added "Shared with me" tab with thumbnail grid linking to `/editFepk/:id`
- Hides filters when "Shared with me" is active
- Replaced button-row filters with `select` dropdowns
- Replaced expanding toggle with pill-style segmented control

**`client/src/components/Filter/FilterWrapper.js`**
- Added `align` prop for right-aligned dropdown positioning

**`client/src/components/Filter/DropDown.css`**
- Added right-align rule + mobile override
- Removed duplicate `border` declaration