### PR TITLE
Feat: Dashboard EPK redesign & Filmmaker Hero video support

### DIFF
--- a/client/src/components/Dashboard/Epks/ArchivedEpkCard.js
+++ b/client/src/components/Dashboard/Epks/ArchivedEpkCard.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import axios from "axios";
+import { useSelector } from "react-redux";
+import http from "../../../http-common";
 import { toast } from "react-toastify";
 import { useTranslation } from "react-i18next";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -7,14 +8,16 @@ import { faRotateLeft } from "@fortawesome/free-solid-svg-icons";
 
 export default function ArchivedEpkCard({ EpkInfo, onRestore }) {
   const { t } = useTranslation();
+  const user = useSelector((state) => state.user);
   const [restoring, setRestoring] = useState(false);
 
   const handleRestore = () => {
     setRestoring(true);
-    const url = `${process.env.REACT_APP_BACKEND_URL}/fepks/restore/${EpkInfo._id}`;
 
-    axios
-      .put(url)
+    http
+      .put(`/fepks/restore/${EpkInfo._id}`, {}, {
+        headers: { Authorization: `Bearer ${user?.token}` },
+      })
       .then(() => {
         toast.success(t("EPK successfully restored."));
         onRestore(EpkInfo._id);
@@ -29,17 +32,17 @@ export default function ArchivedEpkCard({ EpkInfo, onRestore }) {
   };
 
   return (
-    <div className="tw-relative tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-dashed tw-border-gray-300 tw-bg-gray-50 tw-p-4 tw-opacity-70 tw-transition-opacity hover:tw-opacity-100">
+    <div className="tw-relative tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-dashed tw-border-gray-300 tw-bg-gray-50 tw-p-4 tw-opacity-70 tw-transition-opacity hover:tw-opacity-100 tw-w-full tw-max-w-xs">
       {/* Deleted badge */}
-      <span className="tw-absolute tw-right-2 tw-top-2 tw-rounded tw-bg-red-100 tw-px-2 tw-py-0.5 tw-text-xs tw-font-semibold tw-text-red-500">
+      <span className="tw-absolute tw-right-2 tw-top-2 tw-z-10 tw-rounded tw-bg-red-100 tw-px-2 tw-py-0.5 tw-text-xs tw-font-semibold tw-text-red-500">
         {t("Deleted")}
       </span>
 
-      {/* EPK thumbnail / placeholder */}
-      <div className="tw-mb-3 tw-h-24 tw-w-full tw-overflow-hidden tw-rounded tw-bg-gray-200">
-        {EpkInfo.coverImage ? (
+      {/* EPK thumbnail */}
+      <div className="tw-mb-3 tw-mt-5 tw-h-24 tw-w-full tw-overflow-hidden tw-rounded tw-bg-gray-200">
+        {EpkInfo.banner_url ? (
           <img
-            src={EpkInfo.coverImage}
+            src={`${process.env.REACT_APP_AWS_URL}/${EpkInfo.banner_url}`}
             alt={EpkInfo.title}
             className="tw-h-full tw-w-full tw-object-cover tw-grayscale"
           />

--- a/client/src/components/Dashboard/Epks/EpkCard.js
+++ b/client/src/components/Dashboard/Epks/EpkCard.js
@@ -1,93 +1,467 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { useSelector } from "react-redux";
+import { useNavigate, Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faDollarSign,
   faStar,
   faShareNodes,
   faPlus,
-  faUserPlus,
+  faEllipsisVertical,
+  faPen,
+  faUsers,
+  faArrowRightArrowLeft,
+  faTrash,
+  faSearch,
+  faUser,
 } from "@fortawesome/free-solid-svg-icons";
+import { toast } from "react-toastify";
+import http from "../../../http-common";
 import emptyBanner from "../../../images/empty_banner.jpeg";
 import CollaboratorModal from "./CollaboratorModal";
-import { Link } from "react-router-dom";
 
-export default function EpkCard(props) {
-  const epkInfo = props.EpkInfo;
+// Dark dropdown — desktop
+
+function DesktopDropdown({ epkId, isTransferred, onClose, onCollab, onTransfer, onDelete }) {
+  return (
+    <div className="tw-absolute tw-right-0 tw-top-10 tw-w-52 tw-rounded-xl tw-bg-[#1E0039] tw-shadow-2xl tw-py-1.5 tw-z-50 tw-border tw-border-white/10">
+      <Link
+        to={`/epk/${epkId}?edit=true`}
+        className="tw-flex tw-items-center tw-gap-3 tw-px-4 tw-py-2.5 tw-text-sm tw-text-white/90 hover:tw-bg-white/10 tw-no-underline tw-transition-colors"
+        onClick={onClose}
+      >
+        <FontAwesomeIcon icon={faPen} className="tw-w-4 tw-text-white/50" />
+        Edit EPK
+      </Link>
+
+      <div className="tw-my-1 tw-border-t tw-border-white/10" />
+
+      <button
+        onClick={() => { onClose(); onCollab(); }}
+        className="tw-flex tw-w-full tw-items-center tw-gap-3 tw-px-4 tw-py-2.5 tw-text-sm tw-text-white/90 hover:tw-bg-white/10 tw-bg-transparent tw-border-none tw-text-left tw-transition-colors"
+      >
+        <FontAwesomeIcon icon={faUsers} className="tw-w-4 tw-text-white/50" />
+        Manage Collaborators
+      </button>
+
+      <button
+        onClick={() => { onClose(); onTransfer(); }}
+        disabled={isTransferred}
+        className="tw-flex tw-w-full tw-items-center tw-gap-3 tw-px-4 tw-py-2.5 tw-text-sm tw-text-white/90 hover:tw-bg-white/10 tw-bg-transparent tw-border-none tw-text-left tw-transition-colors disabled:tw-opacity-40 disabled:tw-cursor-not-allowed"
+      >
+        <FontAwesomeIcon icon={faArrowRightArrowLeft} className="tw-w-4 tw-text-white/50" />
+        {isTransferred ? "Already Transferred" : "Transfer Ownership"}
+      </button>
+
+      <div className="tw-my-1 tw-border-t tw-border-white/10" />
+
+      <button
+        onClick={() => { onClose(); onDelete(); }}
+        className="tw-flex tw-w-full tw-items-center tw-gap-3 tw-px-4 tw-py-2.5 tw-text-sm tw-text-red-400 hover:tw-bg-white/10 tw-bg-transparent tw-border-none tw-text-left tw-transition-colors"
+      >
+        <FontAwesomeIcon icon={faTrash} className="tw-w-4" />
+        Delete EPK
+      </button>
+    </div>
+  );
+}
+
+// Bottom sheet — mobile
+function MobileBottomSheet({ epkId, isTransferred, title, onClose, onCollab, onTransfer, onDelete }) {
+  return (
+    <div className="tw-fixed tw-inset-0 tw-z-50 md:tw-hidden" onClick={onClose}>
+      {/* backdrop */}
+      <div className="tw-absolute tw-inset-0 tw-bg-black/50" />
+      {/* sheet */}
+      <div
+        className="tw-absolute tw-bottom-0 tw-left-0 tw-right-0 tw-bg-[#1E0039] tw-rounded-t-2xl tw-pb-8 tw-pt-2"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* drag handle */}
+        <div className="tw-mx-auto tw-mb-4 tw-h-1 tw-w-10 tw-rounded-full tw-bg-white/20" />
+
+        {/* EPK title */}
+        <p className="tw-px-6 tw-pb-3 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-widest tw-text-white/40">
+          {title || "EPK"}
+        </p>
+
+        <div className="tw-border-t tw-border-white/10">
+          <Link
+            to={`/epk/${epkId}?edit=true`}
+            className="tw-flex tw-items-center tw-gap-4 tw-px-6 tw-py-4 tw-text-base tw-text-white hover:tw-bg-white/5 tw-no-underline tw-transition-colors"
+            onClick={onClose}
+          >
+            <FontAwesomeIcon icon={faPen} className="tw-w-5 tw-text-white/50" />
+            Edit EPK
+          </Link>
+
+          <button
+            onClick={() => { onClose(); onCollab(); }}
+            className="tw-flex tw-w-full tw-items-center tw-gap-4 tw-px-6 tw-py-4 tw-text-base tw-text-white hover:tw-bg-white/5 tw-bg-transparent tw-border-none tw-text-left tw-transition-colors"
+          >
+            <FontAwesomeIcon icon={faUsers} className="tw-w-5 tw-text-white/50" />
+            Manage Collaborators
+          </button>
+
+          <button
+            onClick={() => { onClose(); onTransfer(); }}
+            disabled={isTransferred}
+            className="tw-flex tw-w-full tw-items-center tw-gap-4 tw-px-6 tw-py-4 tw-text-base tw-text-white hover:tw-bg-white/5 tw-bg-transparent tw-border-none tw-text-left tw-transition-colors disabled:tw-opacity-40"
+          >
+            <FontAwesomeIcon icon={faArrowRightArrowLeft} className="tw-w-5 tw-text-white/50" />
+            {isTransferred ? "Already Transferred" : "Transfer Ownership"}
+          </button>
+
+          <div className="tw-mx-6 tw-border-t tw-border-white/10" />
+
+          <button
+            onClick={() => { onClose(); onDelete(); }}
+            className="tw-flex tw-w-full tw-items-center tw-gap-4 tw-px-6 tw-py-4 tw-text-base tw-text-red-400 hover:tw-bg-white/5 tw-bg-transparent tw-border-none tw-text-left tw-transition-colors"
+          >
+            <FontAwesomeIcon icon={faTrash} className="tw-w-5" />
+            Delete EPK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function EpkCard({ EpkInfo: epkInfo, onDelete }) {
   const user = useSelector((state) => state.user);
-  const [showModal, setShowModal] = useState(false);
+  const navigate = useNavigate();
+
+  const isOwner =
+    user?.id === epkInfo.film_maker?._id || user?.id === epkInfo.film_maker;
 
   const BANNER_IMG =
-    epkInfo.banner_url === ""
+    !epkInfo.banner_url
       ? emptyBanner
       : `${process.env.REACT_APP_AWS_URL}/${epkInfo.banner_url}`;
 
-  const isOwner =
-    user?.id === epkInfo.film_maker?._id ||
-    user?.id === epkInfo.film_maker;
+  // ── Menu state ──────────────────────────────────────────────────────────────
+  const [menuOpen, setMenuOpen] = useState(false);
+  const desktopMenuRef = useRef(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e) => {
+      // On mobile the bottom sheet's backdrop handles closing
+      if (window.innerWidth < 768) return;
+      if (desktopMenuRef.current && !desktopMenuRef.current.contains(e.target)) setMenuOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [menuOpen]);
+
+  // ── Collaborator modal ───────────────────────────────────────────────────────
+  const [showCollabModal, setShowCollabModal] = useState(false);
+
+  // ── Transfer state ───────────────────────────────────────────────────────────
+  const [showTransferModal, setShowTransferModal] = useState(false);
+  const [showTransferConfirm, setShowTransferConfirm] = useState(false);
+  const [transferSearch, setTransferSearch] = useState("");
+  const [transferResults, setTransferResults] = useState([]);
+  const [selectedFilmmaker, setSelectedFilmmaker] = useState(null);
+  const [transferLoading, setTransferLoading] = useState(false);
+  const [isTransferred, setIsTransferred] = useState(false);
+
+  useEffect(() => {
+    const filmmakerId = epkInfo.film_maker?._id ?? epkInfo.film_maker;
+    const transferredFrom = localStorage.getItem(`transferred_${epkInfo._id}`);
+    setIsTransferred(transferredFrom === String(filmmakerId));
+  }, [epkInfo._id, epkInfo.film_maker]);
+
+  useEffect(() => {
+    if (transferSearch.length < 3) { setTransferResults([]); return; }
+    const timeout = setTimeout(() => {
+      http
+        .get(`/filmmaker/searchFilmmakers?name=${encodeURIComponent(transferSearch)}`)
+        .then((res) => setTransferResults(res.data))
+        .catch(() => {});
+    }, 500);
+    return () => clearTimeout(timeout);
+  }, [transferSearch]);
+
+  const handleTransfer = () => {
+    if (!selectedFilmmaker || !epkInfo._id) return;
+    setTransferLoading(true);
+    http
+      .put(`/fepks/${epkInfo._id}/transfer`, {
+        newFilmmakerId: selectedFilmmaker._id,
+      })
+      .then(() => {
+        const filmmakerId = epkInfo.film_maker?._id ?? epkInfo.film_maker;
+        localStorage.setItem(`transferred_${epkInfo._id}`, String(filmmakerId));
+        setIsTransferred(true);
+        toast.success(`EPK transferred to ${selectedFilmmaker.firstName} ${selectedFilmmaker.lastName}!`);
+        setShowTransferConfirm(false);
+        setShowTransferModal(false);
+      })
+      .catch(() => toast.error("Failed to transfer EPK."))
+      .finally(() => setTransferLoading(false));
+  };
+
+  // ── Delete state ─────────────────────────────────────────────────────────────
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deleteText, setDeleteText] = useState("");
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = () => {
+    if (deleteText !== "Delete") return;
+    setIsDeleting(true);
+    http
+      .delete(`/fepks/delete/${epkInfo._id}`, {
+        headers: { Authorization: `Bearer ${user?.token}` },
+      })
+      .then(() => {
+        toast.success("EPK successfully deleted.");
+        setShowDeleteModal(false);
+        if (onDelete) onDelete(epkInfo._id);
+        else navigate("/dashboard/epks");
+      })
+      .catch(() => toast.error("Failed to delete EPK."))
+      .finally(() => { setIsDeleting(false); setDeleteText(""); });
+  };
+
+  const openMenu = (e) => { e.preventDefault(); e.stopPropagation(); setMenuOpen((v) => !v); };
+
+  const filmmakerPicUrl = (pic) =>
+    pic && !pic.startsWith("http") ? `${process.env.REACT_APP_AWS_URL}/${pic}` : pic;
 
   return (
-    <div className="tw-flex tw-flex-row">
-      <div className="tw-m-4 tw-max-w-xs tw-flex-1 tw-rounded-lg tw-border tw-border-gray-200 tw-bg-white tw-shadow hover:tw-scale-105">
-        <Link to={epkInfo.title ? `/editFepk/${epkInfo._id}` : "/"}>
+    <>
+      <div className="tw-group tw-relative tw-flex tw-flex-col tw-rounded-xl tw-border tw-border-gray-100 tw-bg-white tw-shadow-sm hover:tw-shadow-md tw-transition-shadow tw-w-full tw-max-w-xs">
+
+        {/* ── Banner ── */}
+        <Link to={`/epk/${epkInfo._id}`} className="tw-block tw-relative tw-overflow-hidden tw-rounded-t-xl">
           <img
-            className="tw-w-full tw-rounded-b-none tw-rounded-t-lg tw-object-cover"
             src={BANNER_IMG}
-            alt=""
+            alt={epkInfo.title || "EPK"}
+            className="tw-w-full tw-h-40 tw-object-cover"
           />
-          <div className="tw-flex tw-flex-row tw-justify-between tw-p-5">
-            <div className="tw-relative tw-inline-flex">
-              <FontAwesomeIcon icon={faDollarSign} style={{ color: "#1E0039" }} size="2xl" />
-              <span className="tw-absolute tw--right-3 tw--top-3 tw-inline-flex tw-h-5 tw-w-5 tw-items-center tw-justify-center tw-rounded-full tw-border-white tw-bg-red-500 tw-text-xs tw-font-bold tw-text-white">
-                {epkInfo.wishes_to_donate == null ? "0" : epkInfo.wishes_to_donate.length}
-              </span>
-            </div>
-            <div className="tw-relative tw-inline-flex">
-              <FontAwesomeIcon icon={faDollarSign} style={{ color: "#1E0039" }} size="2xl" />
-              <span className="tw-absolute tw--right-3 tw--top-3 tw-inline-flex tw-h-5 tw-w-5 tw-items-center tw-justify-center tw-rounded-full tw-border-white tw-bg-red-500 tw-text-xs tw-font-bold tw-text-white">
-                {epkInfo.wishes_to_buy == null ? "0" : epkInfo.wishes_to_buy.length}
-              </span>
-            </div>
-            <div className="tw-relative tw-inline-flex">
-              <FontAwesomeIcon icon={faStar} style={{ color: "#1E0039" }} size="2xl" />
-              <span className="tw-absolute tw--right-3 tw--top-3 tw-inline-flex tw-h-5 tw-w-5 tw-items-center tw-justify-center tw-rounded-full tw-border-white tw-bg-red-500 tw-text-xs tw-font-bold tw-text-white">
-                {epkInfo.likes == null ? "0" : epkInfo.likes.length}
-              </span>
-            </div>
-            <div className="tw-relative tw-inline-flex">
-              <FontAwesomeIcon icon={faPlus} style={{ color: "#1E0039" }} size="2xl" />
-              <span className="tw-absolute tw--right-3 tw--top-3 tw-inline-flex tw-h-5 tw-w-5 tw-items-center tw-justify-center tw-rounded-full tw-border-white tw-bg-red-500 tw-text-xs tw-font-bold tw-text-white">
-                {epkInfo.favourites == null ? "0" : epkInfo.favourites.length}
-              </span>
-            </div>
-            <div className="tw-relative tw-inline-flex">
-              <FontAwesomeIcon icon={faShareNodes} style={{ color: "#1E0039" }} size="2xl" />
-              <span className="tw-absolute tw--right-3 tw--top-3 tw-inline-flex tw-h-5 tw-w-5 tw-items-center tw-justify-center tw-rounded-full tw-border-white tw-bg-red-500 tw-text-xs tw-font-bold tw-text-white">
-                {epkInfo.sharings == null ? "0" : epkInfo.sharings.length}
-              </span>
-            </div>
+          {/* gradient + title overlay */}
+          <div className="tw-absolute tw-inset-0 tw-bg-gradient-to-t tw-from-black/70 tw-via-black/10 tw-to-transparent tw-flex tw-items-end tw-p-3">
+            <p className="tw-text-white tw-font-semibold tw-text-sm tw-leading-tight tw-line-clamp-2">
+              {epkInfo.title || "Untitled EPK"}
+            </p>
           </div>
         </Link>
 
+        {/* ── ··· button (both breakpoints, on banner) ── */}
         {isOwner && (
-          <div className="tw-border-t tw-border-gray-100 tw-px-5 tw-py-3">
+          <div ref={desktopMenuRef} className="tw-absolute tw-top-2 tw-right-2 tw-z-10">
             <button
-              onClick={() => setShowModal(true)}
-              className="tw-flex tw-bg-transparent tw-items-center tw-gap-2 tw-text-sm tw-text-[#1E0039] hover:tw-underline"
+              onClick={openMenu}
+              className="tw-flex tw-h-8 tw-w-8 tw-items-center tw-justify-center tw-rounded-full tw-bg-black/40 tw-text-white hover:tw-bg-black/60 tw-backdrop-blur-sm tw-transition-colors tw-border-none"
+              title="More options"
             >
-              <FontAwesomeIcon icon={faUserPlus} />
-              Manage Collaborators
+              <FontAwesomeIcon icon={faEllipsisVertical} className="tw-text-sm" />
             </button>
+
+            {/* Dark dropdown — desktop only */}
+            {menuOpen && (
+              <div className="tw-hidden md:tw-block">
+                <DesktopDropdown
+                  epkId={epkInfo._id}
+                  isTransferred={isTransferred}
+                  onClose={() => setMenuOpen(false)}
+                  onCollab={() => setShowCollabModal(true)}
+                  onTransfer={() => { setTransferSearch(""); setSelectedFilmmaker(null); setShowTransferModal(true); }}
+                  onDelete={() => { setDeleteText(""); setShowDeleteModal(true); }}
+                />
+              </div>
+            )}
           </div>
         )}
+
+        {/* ── Stats row ── */}
+        <div className="tw-flex tw-items-center tw-justify-around tw-px-4 tw-py-3 tw-border-t tw-border-gray-100">
+          {[
+            { icon: faDollarSign, count: epkInfo.wishes_to_donate?.length ?? 0, label: "Donations" },
+            { icon: faDollarSign, count: epkInfo.wishes_to_buy?.length ?? 0, label: "Purchases" },
+            { icon: faStar,       count: epkInfo.likes?.length ?? 0, label: "Likes" },
+            { icon: faPlus,       count: epkInfo.favourites?.length ?? 0, label: "Saves" },
+            { icon: faShareNodes, count: epkInfo.sharings?.length ?? 0, label: "Shares" },
+          ].map(({ icon, count, label }) => (
+            <div key={label} className="tw-flex tw-flex-col tw-items-center tw-gap-0.5" title={label}>
+              <FontAwesomeIcon icon={icon} className="tw-text-[#1E0039] tw-text-base" />
+              <span className="tw-text-xs tw-font-semibold tw-text-gray-600">{count}</span>
+            </div>
+          ))}
+        </div>
       </div>
 
-      {showModal && (
-        <CollaboratorModal
+      {/* ── Bottom sheet — mobile only ── */}
+      {menuOpen && isOwner && (
+        <MobileBottomSheet
           epkId={epkInfo._id}
-          onClose={() => setShowModal(false)}
+          isTransferred={isTransferred}
+          title={epkInfo.title}
+          onClose={() => setMenuOpen(false)}
+          onCollab={() => { setMenuOpen(false); setShowCollabModal(true); }}
+          onTransfer={() => { setMenuOpen(false); setTransferSearch(""); setSelectedFilmmaker(null); setShowTransferModal(true); }}
+          onDelete={() => { setMenuOpen(false); setDeleteText(""); setShowDeleteModal(true); }}
         />
       )}
-    </div>
+
+      {/* ── Collaborator Modal ── */}
+      {showCollabModal && (
+        <CollaboratorModal epkId={epkInfo._id} onClose={() => setShowCollabModal(false)} />
+      )}
+
+      {/* ── Transfer Modal ── */}
+      {showTransferModal && (
+        <div className="tw-fixed tw-inset-0 tw-z-50 tw-flex tw-items-center tw-justify-center tw-bg-black/60 tw-p-4">
+          <div className="tw-w-full tw-max-w-md tw-rounded-2xl tw-bg-white tw-p-6 tw-shadow-2xl">
+            <div className="tw-mb-5 tw-flex tw-items-center tw-justify-between">
+              <h2 className="tw-text-lg tw-font-semibold tw-text-[#1E0039]">Transfer Ownership</h2>
+              <button onClick={() => setShowTransferModal(false)} className="tw-text-gray-400 hover:tw-text-gray-600 tw-bg-transparent tw-border-none tw-text-xl tw-leading-none">✕</button>
+            </div>
+
+            <p className="tw-mb-4 tw-text-sm tw-text-gray-500 tw-leading-relaxed">
+              Search for the filmmaker you want to transfer this EPK to. This action is permanent and cannot be undone.
+            </p>
+
+            {/* Search */}
+            <div className="tw-relative tw-mb-3">
+              <FontAwesomeIcon icon={faSearch} className="tw-absolute tw-left-3 tw-top-1/2 tw--translate-y-1/2 tw-text-gray-400 tw-text-sm" />
+              <input
+                type="text"
+                value={transferSearch}
+                onChange={(e) => { setTransferSearch(e.target.value); setSelectedFilmmaker(null); }}
+                placeholder="Search by name..."
+                className="tw-w-full tw-rounded-lg tw-border tw-border-gray-200 tw-pl-9 tw-pr-3 tw-py-2.5 tw-text-sm focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-[#1E0039]/30"
+              />
+            </div>
+
+            {/* Results */}
+            {!selectedFilmmaker && transferResults.length > 0 && (
+              <div className="tw-mb-3 tw-max-h-48 tw-overflow-auto tw-rounded-lg tw-border tw-border-gray-100 tw-divide-y tw-divide-gray-50">
+                {transferResults.map((fm) => (
+                  <button
+                    key={fm._id}
+                    onClick={() => { setSelectedFilmmaker(fm); setTransferSearch(""); setTransferResults([]); }}
+                    className="tw-flex tw-w-full tw-items-center tw-gap-3 tw-px-3 tw-py-2.5 hover:tw-bg-gray-50 tw-bg-transparent tw-border-none tw-text-left"
+                  >
+                    {filmmakerPicUrl(fm.picture) ? (
+                      <img src={filmmakerPicUrl(fm.picture)} alt="" className="tw-h-9 tw-w-9 tw-rounded-full tw-object-cover tw-shrink-0" />
+                    ) : (
+                      <div className="tw-flex tw-h-9 tw-w-9 tw-items-center tw-justify-center tw-rounded-full tw-bg-gray-100 tw-shrink-0">
+                        <FontAwesomeIcon icon={faUser} className="tw-text-gray-400 tw-text-xs" />
+                      </div>
+                    )}
+                    <div>
+                      <p className="tw-text-sm tw-font-medium tw-text-gray-800">{fm.firstName} {fm.lastName}</p>
+                      <p className="tw-text-xs tw-text-gray-400">{fm.role}</p>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* Selected filmmaker */}
+            {selectedFilmmaker && (
+              <div className="tw-mb-4 tw-flex tw-items-center tw-gap-3 tw-rounded-lg tw-border tw-border-[#1E0039]/20 tw-bg-[#1E0039]/5 tw-p-3">
+                {filmmakerPicUrl(selectedFilmmaker.picture) ? (
+                  <img src={filmmakerPicUrl(selectedFilmmaker.picture)} alt="" className="tw-h-10 tw-w-10 tw-rounded-full tw-object-cover tw-shrink-0" />
+                ) : (
+                  <div className="tw-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-rounded-full tw-bg-gray-200 tw-shrink-0">
+                    <FontAwesomeIcon icon={faUser} className="tw-text-gray-400" />
+                  </div>
+                )}
+                <div className="tw-flex-1">
+                  <p className="tw-text-sm tw-font-semibold tw-text-[#1E0039]">{selectedFilmmaker.firstName} {selectedFilmmaker.lastName}</p>
+                  <p className="tw-text-xs tw-text-gray-500">{selectedFilmmaker.role}</p>
+                </div>
+                <button onClick={() => setSelectedFilmmaker(null)} className="tw-text-gray-400 hover:tw-text-gray-600 tw-bg-transparent tw-border-none tw-text-sm">✕</button>
+              </div>
+            )}
+
+            <div className="tw-flex tw-gap-3">
+              <button onClick={() => setShowTransferModal(false)} className="tw-flex-1 tw-rounded-lg tw-border tw-border-gray-200 tw-py-2.5 tw-text-sm tw-font-medium tw-text-gray-600 hover:tw-bg-gray-50 tw-bg-transparent tw-transition-colors">
+                Cancel
+              </button>
+              <button
+                onClick={() => setShowTransferConfirm(true)}
+                disabled={!selectedFilmmaker}
+                className="tw-flex-1 tw-rounded-lg tw-bg-[#1E0039] tw-py-2.5 tw-text-sm tw-font-medium tw-text-white hover:tw-bg-[#2d0059] tw-transition-colors disabled:tw-opacity-40 disabled:tw-cursor-not-allowed tw-border-none"
+              >
+                Transfer Now
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Transfer Confirm Modal ── */}
+      {showTransferConfirm && (
+        <div className="tw-fixed tw-inset-0 tw-z-[60] tw-flex tw-items-center tw-justify-center tw-bg-black/70 tw-p-4">
+          <div className="tw-w-full tw-max-w-sm tw-rounded-2xl tw-bg-white tw-p-6 tw-shadow-2xl">
+            <h3 className="tw-mb-3 tw-text-base tw-font-semibold tw-text-gray-800">Confirm Transfer</h3>
+            <p className="tw-mb-6 tw-text-sm tw-text-gray-500 tw-leading-relaxed">
+              Transferring this EPK to <strong>{selectedFilmmaker?.firstName} {selectedFilmmaker?.lastName}</strong> is permanent and cannot be reversed from your dashboard.
+            </p>
+            <div className="tw-flex tw-gap-3">
+              <button onClick={() => setShowTransferConfirm(false)} className="tw-flex-1 tw-rounded-lg tw-border tw-border-gray-200 tw-py-2.5 tw-text-sm tw-font-medium tw-text-gray-600 hover:tw-bg-gray-50 tw-bg-transparent">
+                Cancel
+              </button>
+              <button
+                onClick={handleTransfer}
+                disabled={transferLoading}
+                className="tw-flex-1 tw-rounded-lg tw-bg-[#1E0039] tw-py-2.5 tw-text-sm tw-font-medium tw-text-white hover:tw-bg-[#2d0059] disabled:tw-opacity-50 tw-border-none tw-transition-colors"
+              >
+                {transferLoading ? "Transferring..." : "Confirm Transfer"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Delete Modal ── */}
+      {showDeleteModal && (
+        <div className="tw-fixed tw-inset-0 tw-z-50 tw-flex tw-items-center tw-justify-center tw-bg-black/60 tw-p-4">
+          <div className="tw-w-full tw-max-w-sm tw-rounded-2xl tw-bg-white tw-p-6 tw-shadow-2xl">
+            <div className="tw-mb-4 tw-flex tw-items-center tw-gap-3">
+              <div className="tw-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-rounded-full tw-bg-red-50 tw-shrink-0">
+                <FontAwesomeIcon icon={faTrash} className="tw-text-red-500" />
+              </div>
+              <div>
+                <h3 className="tw-text-base tw-font-semibold tw-text-gray-800">Delete EPK</h3>
+                <p className="tw-text-xs tw-text-gray-400">This action cannot be undone</p>
+              </div>
+            </div>
+
+            <p className="tw-mb-4 tw-text-sm tw-text-gray-500 tw-leading-relaxed">
+              Type <span className="tw-font-bold tw-text-red-500">Delete</span> to confirm you want to permanently remove this EPK.
+            </p>
+
+            <input
+              type="text"
+              value={deleteText}
+              onChange={(e) => setDeleteText(e.target.value)}
+              placeholder='Type "Delete" to confirm'
+              className="tw-mb-5 tw-w-full tw-rounded-lg tw-border tw-border-gray-200 tw-px-3 tw-py-2.5 tw-text-sm focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-red-400/50"
+            />
+
+            <div className="tw-flex tw-gap-3">
+              <button
+                onClick={() => { setShowDeleteModal(false); setDeleteText(""); }}
+                className="tw-flex-1 tw-rounded-lg tw-border tw-border-gray-200 tw-py-2.5 tw-text-sm tw-font-medium tw-text-gray-600 hover:tw-bg-gray-50 tw-bg-transparent"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={deleteText !== "Delete" || isDeleting}
+                className="tw-flex-1 tw-rounded-lg tw-bg-red-500 tw-py-2.5 tw-text-sm tw-font-medium tw-text-white hover:tw-bg-red-600 disabled:tw-opacity-40 disabled:tw-cursor-not-allowed tw-border-none tw-transition-colors"
+              >
+                {isDeleting ? "Deleting..." : "Delete EPK"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/client/src/components/FilmmakerView/FilmmakerHero/FilmmakerHero.js
+++ b/client/src/components/FilmmakerView/FilmmakerHero/FilmmakerHero.js
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCamera, faMapMarkerAlt } from "@fortawesome/free-solid-svg-icons";
+import { faCamera, faMapMarkerAlt, faPlay, faXmark } from "@fortawesome/free-solid-svg-icons";
 import emptyBanner from '../../../images/empty_banner.jpeg';
 import UpdateProfilePhotoModal from './UpdateProfilePhotoModal';
 import UpdateBannerModal from '../../EpkView/EpkCover/UpdateBannerModal';
 
 const S3 = process.env.REACT_APP_AWS_URL;
 const PHOTO_OVERLAP = 56; // px the photo bleeds below the banner bottom
+const VIDEO_EXTS = ['.mp4', '.mov', '.avi', '.wmv', '.flv', '.webm', '.m4v'];
 
 function resolveUrl(key, fallback) {
   if (!key || key === '') return fallback || emptyBanner;
@@ -14,16 +15,24 @@ function resolveUrl(key, fallback) {
   return `${S3}/${key}`;
 }
 
+function isVideoKey(key) {
+  if (!key) return false;
+  return VIDEO_EXTS.some(ext => key.toLowerCase().includes(ext));
+}
+
 export default function FilmmakerHero({ filmmakerInfo, isEditMode, onChange, errors, clearError }) {
   const [isPhotoModalOpen, setIsPhotoModalOpen]   = useState(false);
   const [isBannerModalOpen, setIsBannerModalOpen] = useState(false);
+  const [isVideoModalOpen, setIsVideoModalOpen]   = useState(false);
 
+  const bannerFile = filmmakerInfo?.new_banner_file;
   const bannerSrc = resolveUrl(
-    filmmakerInfo?.new_banner_file
-      ? URL.createObjectURL(filmmakerInfo.new_banner_file)
-      : filmmakerInfo?.bannerImg,
+    bannerFile ? URL.createObjectURL(bannerFile) : filmmakerInfo?.bannerImg,
     emptyBanner
   );
+  const isBannerVideo =
+    filmmakerInfo?.new_banner_type === 'video' ||
+    (!bannerFile && isVideoKey(filmmakerInfo?.bannerImg));
 
   const photoSrc = resolveUrl(
     filmmakerInfo?.new_picture_file
@@ -37,9 +46,10 @@ export default function FilmmakerHero({ filmmakerInfo, isEditMode, onChange, err
     setIsPhotoModalOpen(false);
   };
 
-  const handleBannerSave = ({ file }) => {
+  const handleBannerSave = ({ file, type }) => {
     if (clearError) clearError('bannerImg');
     onChange('new_banner_file', file);
+    onChange('new_banner_type', type);
     setIsBannerModalOpen(false);
   };
 
@@ -60,12 +70,34 @@ export default function FilmmakerHero({ filmmakerInfo, isEditMode, onChange, err
 
           {/* ── Banner ── */}
           <div className="tw-relative tw-w-full tw-h-[280px] md:tw-h-[360px] tw-overflow-hidden tw-bg-[#280D41]">
-            <img
-              src={bannerSrc}
-              alt="Filmmaker banner"
-              className="tw-w-full tw-h-full tw-object-cover tw-opacity-60"
-            />
+            {isBannerVideo ? (
+              <video
+                src={bannerSrc}
+                muted
+                playsInline
+                preload="metadata"
+                className="tw-w-full tw-h-full tw-object-cover tw-opacity-60"
+              />
+            ) : (
+              <img
+                src={bannerSrc}
+                alt="Filmmaker banner"
+                className="tw-w-full tw-h-full tw-object-cover tw-opacity-60"
+              />
+            )}
             <div className="tw-absolute tw-inset-0 tw-bg-gradient-to-t tw-from-[#1E0039] tw-via-transparent tw-to-transparent" />
+
+            {/* Play button — only on video banners when not editing */}
+            {isBannerVideo && !isEditMode && (
+              <button
+                onClick={() => setIsVideoModalOpen(true)}
+                className="tw-absolute tw-inset-0 tw-flex tw-items-center tw-justify-center tw-bg-transparent tw-border-none tw-cursor-pointer tw-group"
+              >
+                <div className="tw-flex tw-h-16 tw-w-16 tw-items-center tw-justify-center tw-rounded-full tw-bg-white/20 tw-backdrop-blur-sm tw-border tw-border-white/30 tw-transition-all tw-duration-200 group-hover:tw-scale-110 group-hover:tw-bg-white/30">
+                  <FontAwesomeIcon icon={faPlay} className="tw-text-white tw-text-xl tw-ml-1" />
+                </div>
+              </button>
+            )}
 
             {isEditMode && (
               <button
@@ -172,6 +204,28 @@ export default function FilmmakerHero({ filmmakerInfo, isEditMode, onChange, err
         onClose={() => setIsBannerModalOpen(false)}
         onSave={handleBannerSave}
       />
+
+      {/* ── Video lightbox modal ── */}
+      {isVideoModalOpen && (
+        <div
+          className="tw-fixed tw-inset-0 tw-z-[1000] tw-flex tw-items-center tw-justify-center tw-bg-black/90 tw-backdrop-blur-sm"
+          onClick={() => setIsVideoModalOpen(false)}
+        >
+          <button
+            onClick={() => setIsVideoModalOpen(false)}
+            className="tw-absolute tw-top-4 tw-right-4 tw-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-rounded-full tw-bg-white/10 hover:tw-bg-white/20 tw-border-none tw-text-white tw-cursor-pointer tw-transition-colors tw-z-10"
+          >
+            <FontAwesomeIcon icon={faXmark} className="tw-text-lg" />
+          </button>
+          <video
+            src={bannerSrc}
+            controls
+            autoPlay
+            className="tw-max-w-[90vw] tw-max-h-[90vh] tw-rounded-lg tw-shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
     </>
   );
 }

--- a/client/src/components/navbar/NavbarButtons.js
+++ b/client/src/components/navbar/NavbarButtons.js
@@ -94,7 +94,7 @@ function NavbarButtons({ user, setToggle, toggle, ismobile = false }) {
           <div className='tw-mx-4 md:tw-mx-8 tw-flex tw-items-center tw-justify-center'>
             
             {/* CREATE EPK BUTTON (White & Pink) */}
-            {isEpkViewPage && (
+            {isEpkViewPage && !isCollaborator && (
               <button
                 onClick={() => setIsWizardOpen(true)}
                 className="tw-flex tw-items-center tw-justify-center tw-gap-2 tw-bg-white hover:tw-bg-gray-100 tw-text-[#FF00A0] tw-font-bold tw-py-2 tw-px-4 md:tw-px-6 tw-rounded-full tw-shadow-lg tw-transition-all tw-mr-2 md:tw-mr-4 tw-border-none tw-cursor-pointer"

--- a/client/src/pages/Dashboard/EpkPage.js
+++ b/client/src/pages/Dashboard/EpkPage.js
@@ -33,10 +33,19 @@ export default function EpkPage() {
     });
   }, [user.id]);
 
+  const handleDelete = (deletedId) => {
+    const epk = epkList.find((e) => e._id === deletedId);
+    setEpkList((prev) => prev.filter((e) => e._id !== deletedId));
+    if (epk) {
+      setDeletedEpkList((prev) => [{ ...epk, deleted: true }, ...prev]);
+      setShowDeleted(true);
+    }
+  };
+
   const handleRestore = (restoredId) => {
-    setDeletedEpkList((prev) => prev.filter((epk) => epk._id !== restoredId));
-    // Optionally re-fetch active EPKs to reflect restored entry
-    getFepksByFilmmakerId(user.id).then((res) => setEpkList(res));
+    const epk = deletedEpkList.find((e) => e._id === restoredId);
+    setDeletedEpkList((prev) => prev.filter((e) => e._id !== restoredId));
+    if (epk) setEpkList((prev) => [{ ...epk, deleted: false }, ...prev]);
   };
 
   return (
@@ -62,9 +71,13 @@ export default function EpkPage() {
                 <div className="tw-mb-4 tw-flex tw-cursor-pointer tw-justify-center">
                   <NewEpkBtn />
                 </div>
-                <div className="tw-mx-auto tw-grid tw-grid-cols-1 tw-gap-2 md:tw-grid-cols-2 lg:tw-grid-cols-3 xl:tw-grid-cols-4">
+                <div className="tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-2 lg:tw-grid-cols-3 xl:tw-grid-cols-4 tw-justify-items-start">
                   {epkList.map((epk) => (
-                    <EpkCard key={epk._id} EpkInfo={epk} />
+                    <EpkCard
+                      key={epk._id}
+                      EpkInfo={epk}
+                      onDelete={handleDelete}
+                    />
                   ))}
                 </div>
               </>
@@ -93,7 +106,7 @@ export default function EpkPage() {
                 </button>
 
                 {showDeleted && (
-                  <div className="tw-mt-4 tw-mx-auto tw-grid tw-grid-cols-1 tw-gap-2 md:tw-grid-cols-2 lg:tw-grid-cols-3 xl:tw-grid-cols-4">
+                  <div className="tw-mt-4 tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-2 lg:tw-grid-cols-3 xl:tw-grid-cols-4 tw-justify-items-start">
                     {deletedEpkList.map((epk) => (
                       <ArchivedEpkCard
                         key={epk._id}

--- a/client/src/pages/Dashboard/SavedPage.js
+++ b/client/src/pages/Dashboard/SavedPage.js
@@ -45,7 +45,7 @@ export default function SavedPage() {
     Promise.all([
       http.get(`/fepks/getStarredFepksByUser/${userId}`),
       http.get(`/fepks/getFollowingFepksByUser/${userId}`),
-      http.get(`/fepks/getWishToBuyByUser/${userId}`),
+      http.get(`/fepks/getWishTobuyByUser/${userId}`),
       http.get(`/users/followed/${userId}`),
       http.get(`/users/starred/${userId}`),
     ])
@@ -244,7 +244,7 @@ export default function SavedPage() {
                         ? `${process.env.REACT_APP_AWS_URL}/${epk.banner_url}`
                         : moviePic;
                       return (
-                        <a key={epk._id} href={`/editFepk/${epk._id}`} className="tw-transition-transform hover:tw-scale-105">
+                        <a key={epk._id} href={`/epk/${epk._id}?edit=true`} className="tw-transition-transform hover:tw-scale-105">
                           <img src={imgSrc} alt={epk.title} className="tw-aspect-square tw-w-full tw-rounded-lg tw-object-cover" />
                           <p className="tw-mt-1 tw-truncate tw-text-center tw-text-xs tw-text-[#1E0039]">{epk.title}</p>
                         </a>

--- a/server/s3.js
+++ b/server/s3.js
@@ -27,10 +27,11 @@ const checkMimeType = (type) => {
   if (type === "video/mp4") ext = ".mp4";
   else if (type === "video/mpeg") ext = ".mpeg";
   else if (type === "video/quicktime") ext = ".mov";
+  else if (type === "video/webm") ext = ".webm";
   else if (type === "video/x-ms-wmv") ext = ".wmv";
   else if (type === "video/ogg") ext = ".ogg";
   else if (type === "video/3gpp") ext = ".3gp";
-  else if (type === "video/x-msvideo") ext = ".avi"; 
+  else if (type === "video/x-msvideo") ext = ".avi";
   else if (type === "image/png") ext = ".png";
   else if (type === "image/gif") ext = ".gif";
   else if (type === "image/jpg" || type === "image/jpeg") ext = ".jpg";


### PR DESCRIPTION
# Summary

* EPK dashboard kebab menu: replaced the old manage-collaborators link with a `···` dropdown (desktop) and bottom sheet (mobile) per EPK card, consolidating Edit EPK, Manage Collaborators, Transfer Ownership, and Delete into one menu
* Delete & restore workflow fix: soft-delete moves the card to a collapsible "Deleted EPKs" section that auto-expands; restore moves it back, no page refresh needed
* Auth fixes: all EPK delete/restore API calls now send the `Authorization: Bearer` token (previously failed silently against `authUser` middleware)
* Card sizing & alignment: EPK cards left-aligned in the dashboard grid; ArchivedEpkCard matches live card width
* Collaborator gate: collaborators visiting an EPK page no longer see the "Create EPK" button in the navbar
* SavedPage fixes: corrected `getWishToBuyByUser` URL case mismatch (was 404-ing on Linux production); updated "Shared with me" links from legacy `/editFepk/` to `/epk/:id?edit=true`
* Filmmaker Hero video banner: banner conditionally renders `<video>` or `<img>`; play button overlay opens the video in a lightbox at full resolution; video is static in the banner (no autoplay); `video/webm` added to S3 mime-type allowlist