### PR TITLE
feat: social media split layout, filmmaker profile validation, and mobile hero fix

### DIFF
--- a/client/src/components/EpkView/EpkHeader/ActorPageHeader.js
+++ b/client/src/components/EpkView/EpkHeader/ActorPageHeader.js
@@ -29,10 +29,11 @@ export default function ActorPageHeader({ epkInfo, id }) {
 
   return (
     <div className="tw-container tw-mx-auto tw-my-16 tw-w-full">
-      <SocialMedia 
-        socials={socialMediaData} 
+      <SocialMedia
+        socials={socialMediaData}
         totalReachNum={socialMediafollowerTotalNum}
         viewCount={epkInfo?.profileViews || 0}
+        split
       />
     </div>
   );

--- a/client/src/components/EpkView/EpkHeader/EpkHeader.js
+++ b/client/src/components/EpkView/EpkHeader/EpkHeader.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import SocialMedia from "./SocialMedia";
 import { formatCompactNumber } from "../../../utils/numberFormatters";
 import { fetchAndSumFollowers } from "../../../utils/followersHelper";
@@ -57,7 +57,7 @@ export default function EpkHeader({ epkInfo,setGlobalTotalReach,isEditMode,onCha
     { platform: 'instagram', followers: formatCompactNumber(platformFollowers.instagram), url: epkInfo?.film_maker?.instagram_url || epkInfo?.film_maker?.instagram },
     { platform: 'twitter', followers: formatCompactNumber(platformFollowers.twitter), url: epkInfo?.film_maker?.twitter_url || epkInfo?.film_maker?.twitter },
     { platform: 'tiktok', followers: formatCompactNumber(platformFollowers.tiktok), url: epkInfo?.film_maker?.tiktok_url || epkInfo?.film_maker?.tiktok },
-    { platform: 'linkedin', followers: formatCompactNumber(platformFollowers.linkedin || platformFollowers.linkedIn), url: epkInfo?.film_maker?.linkedin_url || epkInfo?.film_maker?.linkedin },
+    { platform: 'linkedin', followers: formatCompactNumber(platformFollowers.linkedin), url: epkInfo?.film_maker?.linkedin_url || epkInfo?.film_maker?.linkedin },
     { platform: 'youtube', followers: formatCompactNumber(platformFollowers.youtube), url: epkInfo?.film_maker?.youtube_url || epkInfo?.film_maker?.youtube }
   ];
 
@@ -103,10 +103,12 @@ export default function EpkHeader({ epkInfo,setGlobalTotalReach,isEditMode,onCha
 
       {/* 2. SOCIAL MEDIA BAR (Stacked directly underneath the title) */}
       <div className="tw-flex tw-w-full tw-items-center tw-justify-evenly tw-gap-5 tw-py-4">
-        <SocialMedia 
-          socials={socialMediaData} 
+        <SocialMedia
+          socials={socialMediaData}
           totalReachNum={socialMediafollowerTotalNum}
           viewCount={epkInfo?.viewCount || 0}
+          split
+          coverLayout
         />
       </div>
       

--- a/client/src/components/EpkView/EpkHeader/SocialMedia.js
+++ b/client/src/components/EpkView/EpkHeader/SocialMedia.js
@@ -1,8 +1,8 @@
-import React, { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect } from "react";
 import SocialMediaIcon from "./SocialMediaIcon";
 import { useTranslation } from 'react-i18next';
 
-export default function SocialMedia({ socials, totalReachNum, viewCount, className = "" }) {
+export default function SocialMedia({ socials, totalReachNum, viewCount, featured = false, split = false, coverLayout = false, className = "" }) {
   const { t } = useTranslation();
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
   const tooltipRef = useRef(null);
@@ -20,64 +20,221 @@ export default function SocialMedia({ socials, totalReachNum, viewCount, classNa
 
   if (!socials || socials.length === 0) return null;
 
-  return (
-    <div className={`tw-w-full tw-flex tw-flex-row tw-flex-wrap tw-justify-center tw-items-center tw-gap-x-10 md:tw-gap-x-40 tw-gap-y-4 ${className}`}>
-      
-      {/* TOTAL AUDIENCE REACH (Clickable Toggle) */}
-      <div 
-        ref={tooltipRef}
-        className="tw-relative tw-flex tw-flex-row tw-items-center tw-justify-center tw-gap-2 tw-cursor-pointer"
-        onClick={() => setIsTooltipOpen(!isTooltipOpen)}
-      >
-        {/* BIGGER TEXT */}
-        <span className="tw-text-base md:tw-text-xl tw-font-bold tw-text-[#C4C4C4] tw-whitespace-nowrap hover:tw-text-white tw-transition-colors">
-          {t('Total Audience Reach')}:
+  // ── Split layout: card left + icons right (desktop) / card → expand (mobile) ──
+  if (split) {
+    const desktopCard = (
+      <div className="tw-flex tw-flex-col tw-items-center tw-gap-1 tw-px-8 tw-py-5 tw-rounded-2xl tw-bg-[#280D41] tw-border tw-border-[#FF43A7]/30 tw-shadow-[0_0_30px_rgba(255,67,167,0.15)]">
+        <span className="tw-text-[#FF43A7] tw-text-[10px] tw-font-bold tw-uppercase tw-tracking-[0.2em]">
+          {t('Total Audience Reach')}
         </span>
-        
-        {/* BIGGER ICON & NUMBER */}
-        <SocialMediaIcon 
-          platform="audience" 
-          followerNum={totalReachNum} 
-          containerClass="tw-flex tw-flex-row tw-items-center tw-gap-1.5"
-          iconClass="tw-h-6 tw-w-6 md:tw-h-8 md:tw-w-8"
-          textClass="tw-text-base md:tw-text-xl tw-font-semibold"
-        />
+        <span className="tw-text-4xl md:tw-text-5xl tw-font-black tw-bg-gradient-to-r tw-from-[#FF43A7] tw-to-[#c026d3] tw-bg-clip-text tw-text-transparent tw-leading-tight">
+          {totalReachNum}
+        </span>
+        <span className="tw-text-[#E2BDC9]/60 tw-text-xs tw-mt-0.5">across all platforms</span>
+      </div>
+    );
 
-        {/* THE TOOLTIP POPOVER */}
-        {isTooltipOpen && (
-          <div className="tw-absolute tw-top-[140%] tw-z-[9999] tw-w-[300px] sm:tw-w-[320px] md:tw-w-max tw-bg-[#30134A] tw-border tw-border-white/20 tw-shadow-2xl tw-rounded-xl tw-p-5 tw-animate-fade-in-up">
-            
-            <div className="tw-absolute tw--top-2 tw-left-1/2 tw--translate-x-1/2 tw-w-4 tw-h-4 tw-bg-[#30134A] tw-rotate-45 tw-border-t tw-border-l tw-border-white/20"></div>
-
-            <div className="tw-grid tw-grid-cols-4 md:tw-flex md:tw-flex-row md:tw-flex-nowrap tw-gap-x-2 md:tw-gap-x-6 tw-gap-y-6 tw-justify-items-center tw-justify-center">
-            {socials.map((social, index) => (
-            <SocialMediaIcon 
-            key={index} 
+    const iconGrid = (extraClass = '') => (
+      <div className={`tw-flex tw-flex-wrap tw-gap-x-5 md:tw-gap-x-7 tw-gap-y-4 tw-justify-center ${extraClass}`}>
+        {socials.map((social, index) => (
+          <SocialMediaIcon
+            key={index}
             platform={social.platform}
-            followerNum={social.followers} 
+            followerNum={social.followers}
             url={social.url}
-            color={social.url ? "#E81A84" : "#868585"} 
-            textColor="white" 
+            color={social.url ? "#E81A84" : "#868585"}
+            textColor="white"
             containerClass="tw-flex tw-flex-col tw-items-center tw-justify-center tw-w-[50px] md:tw-w-[60px]"
             iconClass="tw-h-6 tw-w-6 md:tw-h-7 md:tw-w-7"
             textClass="tw-text-[10px] md:tw-text-xs tw-font-bold tw-mt-2"
-            />
-            ))}
+          />
+        ))}
+        {!!viewCount && (
+          <SocialMediaIcon
+            platform="views"
+            followerNum={viewCount}
+            containerClass="tw-flex tw-flex-col tw-items-center tw-justify-center tw-w-[50px] md:tw-w-[60px]"
+            iconClass="tw-h-6 tw-w-6 md:tw-h-7 md:tw-w-7"
+            textClass="tw-text-[10px] md:tw-text-xs tw-font-bold tw-mt-2"
+          />
+        )}
+      </div>
+    );
+
+    // Mobile: clickable card that expands the icon list — shared by all split variants
+    const mobileSection = (
+      <div className="tw-flex sm:tw-hidden tw-flex-col tw-items-center tw-gap-4 tw-w-full" ref={tooltipRef}>
+        <div
+          onClick={() => setIsTooltipOpen(!isTooltipOpen)}
+          className="tw-flex tw-flex-col tw-items-center tw-gap-1 tw-px-8 tw-py-5 tw-rounded-2xl tw-bg-[#280D41] tw-border tw-border-[#FF43A7]/30 tw-shadow-[0_0_30px_rgba(255,67,167,0.15)] tw-cursor-pointer tw-transition-all tw-duration-200 hover:tw-border-[#FF43A7]/60 hover:tw-shadow-[0_0_40px_rgba(255,67,167,0.25)] tw-select-none"
+        >
+          <span className="tw-text-[#FF43A7] tw-text-[10px] tw-font-bold tw-uppercase tw-tracking-[0.2em]">
+            {t('Total Audience Reach')}
+          </span>
+          <span className="tw-text-4xl tw-font-black tw-bg-gradient-to-r tw-from-[#FF43A7] tw-to-[#c026d3] tw-bg-clip-text tw-text-transparent tw-leading-tight">
+            {totalReachNum}
+          </span>
+          <span className="tw-text-[#E2BDC9]/60 tw-text-xs tw-mt-0.5">
+            across all platforms {isTooltipOpen ? '▴' : '▾'}
+          </span>
+        </div>
+
+        {isTooltipOpen && (
+          <div className="tw-w-full tw-rounded-xl tw-bg-[#30134A] tw-border tw-border-white/20 tw-shadow-xl tw-p-5">
+            <div className="tw-grid tw-grid-cols-4 tw-gap-x-2 tw-gap-y-6 tw-justify-items-center">
+              {socials.map((social, index) => (
+                <SocialMediaIcon
+                  key={index}
+                  platform={social.platform}
+                  followerNum={social.followers}
+                  url={social.url}
+                  color={social.url ? "#E81A84" : "#868585"}
+                  textColor="white"
+                  containerClass="tw-flex tw-flex-col tw-items-center tw-justify-center tw-w-[50px]"
+                  iconClass="tw-h-6 tw-w-6"
+                  textClass="tw-text-[10px] tw-font-bold tw-mt-2"
+                />
+              ))}
+              {!!viewCount && (
+                <SocialMediaIcon
+                  platform="views"
+                  followerNum={viewCount}
+                  containerClass="tw-flex tw-flex-col tw-items-center tw-justify-center tw-w-[50px]"
+                  iconClass="tw-h-6 tw-w-6"
+                  textClass="tw-text-[10px] tw-font-bold tw-mt-2"
+                />
+              )}
             </div>
           </div>
         )}
       </div>
+    );
+
+    if (coverLayout) {
+      return (
+        <div className={`tw-w-full ${className}`}>
+          {/* Desktop: aligned to EpkCover poster(343px) / banner(flex-1) columns */}
+          <div className="tw-hidden sm:tw-flex tw-w-full tw-max-w-[1280px] tw-mx-auto tw-gap-8 tw-items-center tw-py-2">
+            <div className="tw-w-[343px] tw-shrink-0 tw-flex tw-justify-center">
+              {desktopCard}
+            </div>
+            <div className="tw-w-px tw-self-stretch tw-bg-[#5A3F49]/40" />
+            <div className="tw-flex-1 tw-flex tw-items-center tw-justify-center">
+              {iconGrid()}
+            </div>
+          </div>
+          {mobileSection}
+        </div>
+      );
+    }
+
+    return (
+      <div className={`tw-w-full ${className}`}>
+        {/* Desktop: centered split row */}
+        <div className="tw-hidden sm:tw-flex tw-items-center tw-justify-center tw-gap-6">
+          {desktopCard}
+          <div className="tw-w-px tw-self-stretch tw-bg-[#5A3F49]/40 tw-shrink-0" />
+          {iconGrid()}
+        </div>
+        {mobileSection}
+      </div>
+    );
+  }
+
+  return (
+    <div className={`tw-w-full tw-flex tw-flex-row tw-flex-wrap tw-justify-center tw-items-center tw-gap-x-10 md:tw-gap-x-40 tw-gap-y-4 ${className}`}>
+      
+      {/* TOTAL AUDIENCE REACH (Clickable Toggle) */}
+      {featured ? (
+        <div
+          ref={tooltipRef}
+          onClick={() => setIsTooltipOpen(!isTooltipOpen)}
+          className="tw-relative tw-flex tw-flex-col tw-items-center tw-gap-1 tw-px-8 tw-py-5 tw-rounded-2xl tw-bg-[#280D41] tw-border tw-border-[#FF43A7]/30 tw-shadow-[0_0_30px_rgba(255,67,167,0.15)] tw-cursor-pointer tw-transition-all tw-duration-200 hover:tw-border-[#FF43A7]/60 hover:tw-shadow-[0_0_40px_rgba(255,67,167,0.25)] tw-select-none"
+        >
+          <span className="tw-text-[#FF43A7] tw-text-[10px] tw-font-bold tw-uppercase tw-tracking-[0.2em]">
+            {t('Total Audience Reach')}
+          </span>
+          <span className="tw-text-4xl md:tw-text-5xl tw-font-black tw-bg-gradient-to-r tw-from-[#FF43A7] tw-to-[#c026d3] tw-bg-clip-text tw-text-transparent tw-leading-tight">
+            {totalReachNum}
+          </span>
+          <span className="tw-text-[#E2BDC9]/60 tw-text-xs tw-mt-0.5">
+            across all platforms {isTooltipOpen ? '▴' : '▾'}
+          </span>
+
+          {isTooltipOpen && (
+            <div className="tw-absolute tw-top-[calc(100%+12px)] tw-left-1/2 tw--translate-x-1/2 tw-z-[9999] tw-w-[300px] sm:tw-w-[340px] md:tw-w-max tw-bg-[#30134A] tw-border tw-border-white/20 tw-shadow-2xl tw-rounded-xl tw-p-5 tw-animate-fade-in-up">
+              <div className="tw-absolute tw--top-2 tw-left-1/2 tw--translate-x-1/2 tw-w-4 tw-h-4 tw-bg-[#30134A] tw-rotate-45 tw-border-t tw-border-l tw-border-white/20" />
+              <div className="tw-grid tw-grid-cols-4 md:tw-flex md:tw-flex-row md:tw-flex-nowrap tw-gap-x-2 md:tw-gap-x-6 tw-gap-y-6 tw-justify-items-center tw-justify-center">
+                {socials.map((social, index) => (
+                  <SocialMediaIcon
+                    key={index}
+                    platform={social.platform}
+                    followerNum={social.followers}
+                    url={social.url}
+                    color={social.url ? "#E81A84" : "#868585"}
+                    textColor="white"
+                    containerClass="tw-flex tw-flex-col tw-items-center tw-justify-center tw-w-[50px] md:tw-w-[60px]"
+                    iconClass="tw-h-6 tw-w-6 md:tw-h-7 md:tw-w-7"
+                    textClass="tw-text-[10px] md:tw-text-xs tw-font-bold tw-mt-2"
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div
+          ref={tooltipRef}
+          className="tw-relative tw-flex tw-flex-row tw-items-center tw-justify-center tw-gap-2 tw-cursor-pointer"
+          onClick={() => setIsTooltipOpen(!isTooltipOpen)}
+        >
+          <span className="tw-text-base md:tw-text-xl tw-font-bold tw-text-[#C4C4C4] tw-whitespace-nowrap hover:tw-text-white tw-transition-colors">
+            {t('Total Audience Reach')}:
+          </span>
+
+          <SocialMediaIcon
+            platform="audience"
+            followerNum={totalReachNum}
+            containerClass="tw-flex tw-flex-row tw-items-center tw-gap-1.5"
+            iconClass="tw-h-6 tw-w-6 md:tw-h-8 md:tw-w-8"
+            textClass="tw-text-base md:tw-text-xl tw-font-semibold"
+          />
+
+          {isTooltipOpen && (
+            <div className="tw-absolute tw-top-[140%] tw-z-[9999] tw-w-[300px] sm:tw-w-[320px] md:tw-w-max tw-bg-[#30134A] tw-border tw-border-white/20 tw-shadow-2xl tw-rounded-xl tw-p-5 tw-animate-fade-in-up">
+              <div className="tw-absolute tw--top-2 tw-left-1/2 tw--translate-x-1/2 tw-w-4 tw-h-4 tw-bg-[#30134A] tw-rotate-45 tw-border-t tw-border-l tw-border-white/20" />
+              <div className="tw-grid tw-grid-cols-4 md:tw-flex md:tw-flex-row md:tw-flex-nowrap tw-gap-x-2 md:tw-gap-x-6 tw-gap-y-6 tw-justify-items-center tw-justify-center">
+                {socials.map((social, index) => (
+                  <SocialMediaIcon
+                    key={index}
+                    platform={social.platform}
+                    followerNum={social.followers}
+                    url={social.url}
+                    color={social.url ? "#E81A84" : "#868585"}
+                    textColor="white"
+                    containerClass="tw-flex tw-flex-col tw-items-center tw-justify-center tw-w-[50px] md:tw-w-[60px]"
+                    iconClass="tw-h-6 tw-w-6 md:tw-h-7 md:tw-w-7"
+                    textClass="tw-text-[10px] md:tw-text-xs tw-font-bold tw-mt-2"
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* VIEWS STAT */}
-      <div className="tw-flex tw-flex-row tw-items-center tw-justify-center tw-gap-2">
-        <SocialMediaIcon 
-          platform="views" 
-          followerNum={viewCount} 
-          containerClass="tw-flex tw-flex-row tw-items-center tw-gap-1.5"
-          iconClass="tw-h-6 tw-w-6 md:tw-h-8 md:tw-w-8"
-          textClass="tw-text-base md:tw-text-xl tw-font-semibold"
-        />
-      </div>
+      {!featured && (
+        <div className="tw-flex tw-flex-row tw-items-center tw-justify-center tw-gap-2">
+          <SocialMediaIcon
+            platform="views"
+            followerNum={viewCount}
+            containerClass="tw-flex tw-flex-row tw-items-center tw-gap-1.5"
+            iconClass="tw-h-6 tw-w-6 md:tw-h-8 md:tw-w-8"
+            textClass="tw-text-base md:tw-text-xl tw-font-semibold"
+          />
+        </div>
+      )}
 
     </div>
   );

--- a/client/src/components/FilmmakerView/FilmmakerBio/FilmmakerBio.js
+++ b/client/src/components/FilmmakerView/FilmmakerBio/FilmmakerBio.js
@@ -1,6 +1,8 @@
 import React from 'react';
 
-export default function FilmmakerBio({ filmmakerInfo, isEditMode, onChange }) {
+export default function FilmmakerBio({ filmmakerInfo, isEditMode, onChange, errors }) {
+  const bioLength = filmmakerInfo?.aboutMe?.length || 0;
+
   return (
     <div className="tw-w-full tw-px-6 md:tw-px-12 tw-py-10 tw-border-t tw-border-[#5A3F49]/30">
       <h2 className="tw-text-[#FF43A7] tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-mb-6">
@@ -8,12 +10,18 @@ export default function FilmmakerBio({ filmmakerInfo, isEditMode, onChange }) {
       </h2>
 
       {isEditMode ? (
-        <textarea
-          value={filmmakerInfo?.aboutMe || ''}
-          onChange={(e) => onChange('aboutMe', e.target.value)}
-          placeholder="Write about yourself — your background, approach to filmmaking, achievements, and what drives your creative vision..."
-          className="tw-w-full tw-min-h-[180px] tw-bg-[#280D41] tw-border tw-border-[#5A3F49] focus:tw-border-[#FF43A7] tw-rounded-xl tw-px-5 tw-py-4 tw-text-white tw-text-base tw-leading-relaxed tw-outline-none tw-transition-colors tw-resize-y custom-scrollbar"
-        />
+        <div>
+          <textarea
+            value={filmmakerInfo?.aboutMe || ''}
+            onChange={(e) => onChange('aboutMe', e.target.value)}
+            placeholder="Write about yourself — your background, approach to filmmaking, achievements, and what drives your creative vision..."
+            className={`tw-w-full tw-min-h-[180px] tw-bg-[#280D41] tw-border ${errors?.aboutMe ? 'tw-border-red-500' : 'tw-border-[#5A3F49]'} focus:tw-border-[#FF43A7] tw-rounded-xl tw-px-5 tw-py-4 tw-text-white tw-text-base tw-leading-relaxed tw-outline-none tw-transition-colors tw-resize-y custom-scrollbar`}
+          />
+          <div className="tw-flex tw-justify-between tw-mt-1.5">
+            <span>{errors?.aboutMe && <span className="tw-text-red-400 tw-text-xs">{errors.aboutMe}</span>}</span>
+            <span className={`tw-text-xs ${bioLength > 2000 ? 'tw-text-red-400' : 'tw-text-[#5A3F49]'}`}>{bioLength}/2000</span>
+          </div>
+        </div>
       ) : filmmakerInfo?.aboutMe ? (
         <p className="tw-text-[#E2BDC9] tw-text-base tw-leading-relaxed tw-max-w-4xl tw-m-0">
           {filmmakerInfo.aboutMe}

--- a/client/src/components/FilmmakerView/FilmmakerContact/FilmmakerContact.js
+++ b/client/src/components/FilmmakerView/FilmmakerContact/FilmmakerContact.js
@@ -2,18 +2,21 @@ import React from 'react';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGlobe, faEnvelope, faPhone } from "@fortawesome/free-solid-svg-icons";
 
-function ContactField({ icon, href, value, isEditMode, field, placeholder, type = 'text', onChange }) {
+function ContactField({ icon, href, value, isEditMode, field, placeholder, type = 'text', onChange, error }) {
   if (isEditMode) {
     return (
-      <div className="tw-flex tw-items-center tw-gap-3">
-        <FontAwesomeIcon icon={icon} className="tw-text-[#FF43A7] tw-text-sm tw-w-4 tw-shrink-0" />
-        <input
-          type={type}
-          value={value || ''}
-          onChange={(e) => onChange(field, e.target.value)}
-          placeholder={placeholder}
-          className="tw-flex-1 tw-bg-[#280D41] tw-border tw-border-[#5A3F49] focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-3 tw-py-2 tw-text-white tw-text-sm tw-outline-none tw-transition-colors"
-        />
+      <div className="tw-flex tw-flex-col tw-gap-1">
+        <div className="tw-flex tw-items-center tw-gap-3">
+          <FontAwesomeIcon icon={icon} className="tw-text-[#FF43A7] tw-text-sm tw-w-4 tw-shrink-0" />
+          <input
+            type={type}
+            value={value || ''}
+            onChange={(e) => onChange(field, e.target.value)}
+            placeholder={placeholder}
+            className={`tw-flex-1 tw-bg-[#280D41] tw-border ${error ? 'tw-border-red-500' : 'tw-border-[#5A3F49]'} focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-3 tw-py-2 tw-text-white tw-text-sm tw-outline-none tw-transition-colors`}
+          />
+        </div>
+        {error && <p className="tw-text-red-400 tw-text-xs tw-m-0 tw-pl-7">{error}</p>}
       </div>
     );
   }
@@ -32,7 +35,7 @@ function ContactField({ icon, href, value, isEditMode, field, placeholder, type 
     : content;
 }
 
-export default function FilmmakerContact({ filmmakerInfo, isEditMode, onChange }) {
+export default function FilmmakerContact({ filmmakerInfo, isEditMode, onChange, errors }) {
   const hasAnyContact = filmmakerInfo?.website || filmmakerInfo?.email || filmmakerInfo?.phone;
 
   if (!isEditMode && !hasAnyContact) return null;
@@ -53,6 +56,7 @@ export default function FilmmakerContact({ filmmakerInfo, isEditMode, onChange }
           placeholder="https://yourwebsite.com"
           type="url"
           onChange={onChange}
+          error={errors?.website}
         />
         <ContactField
           icon={faEnvelope}
@@ -63,6 +67,7 @@ export default function FilmmakerContact({ filmmakerInfo, isEditMode, onChange }
           placeholder="contact@email.com"
           type="email"
           onChange={onChange}
+          error={errors?.email}
         />
         <ContactField
           icon={faPhone}
@@ -72,6 +77,7 @@ export default function FilmmakerContact({ filmmakerInfo, isEditMode, onChange }
           placeholder="+1 (555) 000-0000"
           type="tel"
           onChange={onChange}
+          error={errors?.phone}
         />
       </div>
     </div>

--- a/client/src/components/FilmmakerView/FilmmakerHero/FilmmakerHero.js
+++ b/client/src/components/FilmmakerView/FilmmakerHero/FilmmakerHero.js
@@ -61,60 +61,55 @@ export default function FilmmakerHero({ filmmakerInfo, isEditMode, onChange, err
     <>
       <div className="tw-w-full">
 
-        {/*
-          Outer wrapper is tw-relative so the photo can be absolutely positioned
-          against it. The inner banner div handles its own overflow-hidden for
-          the image crop — the photo lives OUTSIDE that div so it is never clipped.
-        */}
-        <div className="tw-relative" style={{ paddingBottom: PHOTO_OVERLAP }}>
+        {/* ── Banner ── */}
+        <div className="tw-relative tw-w-full tw-h-[280px] md:tw-h-[360px] tw-overflow-hidden tw-bg-[#280D41]">
+          {isBannerVideo ? (
+            <video
+              src={bannerSrc}
+              muted
+              playsInline
+              preload="metadata"
+              className="tw-w-full tw-h-full tw-object-cover tw-opacity-60"
+            />
+          ) : (
+            <img
+              src={bannerSrc}
+              alt="Filmmaker banner"
+              className="tw-w-full tw-h-full tw-object-cover tw-opacity-60"
+            />
+          )}
+          <div className="tw-absolute tw-inset-0 tw-bg-gradient-to-t tw-from-[#1E0039] tw-via-transparent tw-to-transparent" />
 
-          {/* ── Banner ── */}
-          <div className="tw-relative tw-w-full tw-h-[280px] md:tw-h-[360px] tw-overflow-hidden tw-bg-[#280D41]">
-            {isBannerVideo ? (
-              <video
-                src={bannerSrc}
-                muted
-                playsInline
-                preload="metadata"
-                className="tw-w-full tw-h-full tw-object-cover tw-opacity-60"
-              />
-            ) : (
-              <img
-                src={bannerSrc}
-                alt="Filmmaker banner"
-                className="tw-w-full tw-h-full tw-object-cover tw-opacity-60"
-              />
-            )}
-            <div className="tw-absolute tw-inset-0 tw-bg-gradient-to-t tw-from-[#1E0039] tw-via-transparent tw-to-transparent" />
+          {/* Play button — only on video banners when not editing */}
+          {isBannerVideo && !isEditMode && (
+            <button
+              onClick={() => setIsVideoModalOpen(true)}
+              className="tw-absolute tw-inset-0 tw-flex tw-items-center tw-justify-center tw-bg-transparent tw-border-none tw-cursor-pointer tw-group"
+            >
+              <div className="tw-flex tw-h-16 tw-w-16 tw-items-center tw-justify-center tw-rounded-full tw-bg-white/20 tw-backdrop-blur-sm tw-border tw-border-white/30 tw-transition-all tw-duration-200 group-hover:tw-scale-110 group-hover:tw-bg-white/30">
+                <FontAwesomeIcon icon={faPlay} className="tw-text-white tw-text-xl tw-ml-1" />
+              </div>
+            </button>
+          )}
 
-            {/* Play button — only on video banners when not editing */}
-            {isBannerVideo && !isEditMode && (
-              <button
-                onClick={() => setIsVideoModalOpen(true)}
-                className="tw-absolute tw-inset-0 tw-flex tw-items-center tw-justify-center tw-bg-transparent tw-border-none tw-cursor-pointer tw-group"
-              >
-                <div className="tw-flex tw-h-16 tw-w-16 tw-items-center tw-justify-center tw-rounded-full tw-bg-white/20 tw-backdrop-blur-sm tw-border tw-border-white/30 tw-transition-all tw-duration-200 group-hover:tw-scale-110 group-hover:tw-bg-white/30">
-                  <FontAwesomeIcon icon={faPlay} className="tw-text-white tw-text-xl tw-ml-1" />
-                </div>
-              </button>
-            )}
+          {isEditMode && (
+            <button
+              onClick={() => setIsBannerModalOpen(true)}
+              className="tw-absolute tw-top-4 tw-right-4 tw-flex tw-items-center tw-gap-2 tw-bg-black/60 hover:tw-bg-black/80 tw-text-white tw-text-xs tw-font-bold tw-uppercase tw-px-4 tw-py-2 tw-rounded-lg tw-border tw-border-white/20 tw-transition-colors tw-cursor-pointer"
+            >
+              <FontAwesomeIcon icon={faCamera} />
+              <span className="tw-hidden sm:tw-inline">Change Banner</span>
+            </button>
+          )}
+        </div>
 
-            {isEditMode && (
-              <button
-                onClick={() => setIsBannerModalOpen(true)}
-                className="tw-absolute tw-top-4 tw-right-4 tw-flex tw-items-center tw-gap-2 tw-bg-black/60 hover:tw-bg-black/80 tw-text-white tw-text-xs tw-font-bold tw-uppercase tw-px-4 tw-py-2 tw-rounded-lg tw-border tw-border-white/20 tw-transition-colors tw-cursor-pointer"
-              >
-                <FontAwesomeIcon icon={faCamera} />
-                <span className="tw-hidden sm:tw-inline">Change Banner</span>
-              </button>
-            )}
-          </div>
-
-          {/* ── Profile photo — outside the overflow-hidden banner ── */}
-          <div
-            className="tw-absolute tw-left-6 md:tw-left-12 tw-group"
-            style={{ bottom: 0 }}
-          >
+        {/* ── Photo + Name row — photo bleeds into banner via negative margin ── */}
+        <div
+          className="tw-flex tw-flex-row tw-items-center tw-px-6 md:tw-px-12 tw-gap-4 md:tw-gap-6 tw-pb-8"
+          style={{ marginTop: `-${PHOTO_OVERLAP}px` }}
+        >
+          {/* Profile photo */}
+          <div className="tw-relative tw-shrink-0 tw-z-10 tw-group">
             <img
               src={photoSrc}
               alt={`${filmmakerInfo?.firstName} ${filmmakerInfo?.lastName}`}
@@ -129,29 +124,32 @@ export default function FilmmakerHero({ filmmakerInfo, isEditMode, onChange, err
               </div>
             )}
           </div>
-        </div>
 
-        {/* ── Name / role / location — always fully below the banner ── */}
-        <div className="tw-px-6 md:tw-px-12 tw-pt-4 tw-pb-8"
-             style={{ paddingLeft: `calc(1.5rem + 112px + 1.5rem)` }}>
-          <div className="tw-flex tw-flex-col tw-gap-2">
+          {/* Name / role / location */}
+          <div className="tw-flex tw-flex-col tw-gap-2 tw-pt-[56px]">
 
             {isEditMode ? (
               <div className="tw-flex tw-flex-col sm:tw-flex-row tw-gap-3">
-                <input
-                  type="text"
-                  value={filmmakerInfo?.firstName || ''}
-                  onChange={(e) => onChange('firstName', e.target.value)}
-                  placeholder="First name"
-                  className="tw-bg-[#280D41] tw-border tw-border-[#5A3F49] focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-3 tw-py-2 tw-text-white tw-font-bold tw-text-xl tw-outline-none tw-transition-colors"
-                />
-                <input
-                  type="text"
-                  value={filmmakerInfo?.lastName || ''}
-                  onChange={(e) => onChange('lastName', e.target.value)}
-                  placeholder="Last name"
-                  className="tw-bg-[#280D41] tw-border tw-border-[#5A3F49] focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-3 tw-py-2 tw-text-white tw-font-bold tw-text-xl tw-outline-none tw-transition-colors"
-                />
+                <div className="tw-flex tw-flex-col tw-gap-1">
+                  <input
+                    type="text"
+                    value={filmmakerInfo?.firstName || ''}
+                    onChange={(e) => onChange('firstName', e.target.value)}
+                    placeholder="First name"
+                    className={`tw-bg-[#280D41] tw-border ${errors?.firstName ? 'tw-border-red-500' : 'tw-border-[#5A3F49]'} focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-3 tw-py-2 tw-text-white tw-font-bold tw-text-xl tw-outline-none tw-transition-colors`}
+                  />
+                  {errors?.firstName && <p className="tw-text-red-400 tw-text-xs tw-m-0">{errors.firstName}</p>}
+                </div>
+                <div className="tw-flex tw-flex-col tw-gap-1">
+                  <input
+                    type="text"
+                    value={filmmakerInfo?.lastName || ''}
+                    onChange={(e) => onChange('lastName', e.target.value)}
+                    placeholder="Last name"
+                    className={`tw-bg-[#280D41] tw-border ${errors?.lastName ? 'tw-border-red-500' : 'tw-border-[#5A3F49]'} focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-3 tw-py-2 tw-text-white tw-font-bold tw-text-xl tw-outline-none tw-transition-colors`}
+                  />
+                  {errors?.lastName && <p className="tw-text-red-400 tw-text-xs tw-m-0">{errors.lastName}</p>}
+                </div>
               </div>
             ) : (
               <h1 className="tw-text-white tw-text-3xl md:tw-text-4xl tw-font-bold tw-m-0">
@@ -165,21 +163,27 @@ export default function FilmmakerHero({ filmmakerInfo, isEditMode, onChange, err
               </span>
 
               {isEditMode ? (
-                <div className="tw-flex tw-gap-2">
-                  <input
-                    type="text"
-                    value={filmmakerInfo?.city || ''}
-                    onChange={(e) => onChange('city', e.target.value)}
-                    placeholder="City"
-                    className="tw-bg-[#280D41] tw-border tw-border-[#5A3F49] focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-2 tw-py-1 tw-text-[#E2BDC9] tw-text-sm tw-outline-none tw-transition-colors tw-w-28"
-                  />
-                  <input
-                    type="text"
-                    value={filmmakerInfo?.country || ''}
-                    onChange={(e) => onChange('country', e.target.value)}
-                    placeholder="Country"
-                    className="tw-bg-[#280D41] tw-border tw-border-[#5A3F49] focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-2 tw-py-1 tw-text-[#E2BDC9] tw-text-sm tw-outline-none tw-transition-colors tw-w-28"
-                  />
+                <div className="tw-flex tw-gap-2 tw-items-start">
+                  <div className="tw-flex tw-flex-col tw-gap-1">
+                    <input
+                      type="text"
+                      value={filmmakerInfo?.city || ''}
+                      onChange={(e) => onChange('city', e.target.value)}
+                      placeholder="City"
+                      className={`tw-bg-[#280D41] tw-border ${errors?.city ? 'tw-border-red-500' : 'tw-border-[#5A3F49]'} focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-2 tw-py-1 tw-text-[#E2BDC9] tw-text-sm tw-outline-none tw-transition-colors tw-w-28`}
+                    />
+                    {errors?.city && <p className="tw-text-red-400 tw-text-xs tw-m-0">{errors.city}</p>}
+                  </div>
+                  <div className="tw-flex tw-flex-col tw-gap-1">
+                    <input
+                      type="text"
+                      value={filmmakerInfo?.country || ''}
+                      onChange={(e) => onChange('country', e.target.value)}
+                      placeholder="Country"
+                      className={`tw-bg-[#280D41] tw-border ${errors?.country ? 'tw-border-red-500' : 'tw-border-[#5A3F49]'} focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-2 tw-py-1 tw-text-[#E2BDC9] tw-text-sm tw-outline-none tw-transition-colors tw-w-28`}
+                    />
+                    {errors?.country && <p className="tw-text-red-400 tw-text-xs tw-m-0">{errors.country}</p>}
+                  </div>
                 </div>
               ) : location ? (
                 <span className="tw-flex tw-items-center tw-gap-1.5 tw-text-[#E2BDC9] tw-text-sm">

--- a/client/src/components/FilmmakerView/FilmmakerSocial/FilmmakerSocial.js
+++ b/client/src/components/FilmmakerView/FilmmakerSocial/FilmmakerSocial.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import SocialMedia from '../../EpkView/EpkHeader/SocialMedia';
 import { formatCompactNumber } from '../../../utils/numberFormatters';
 import { fetchAndSumFollowers } from '../../../utils/followersHelper';
@@ -12,11 +12,10 @@ const PLATFORMS = [
   { key: 'linkedin',  label: 'LinkedIn',  urlField: 'linkedin_url',  followersField: 'linkedin_followers' },
 ];
 
-export default function FilmmakerSocial({ filmmakerInfo, isEditMode, onChange }) {
+export default function FilmmakerSocial({ filmmakerInfo, isEditMode, onChange, errors }) {
   const [platformFollowers, setPlatformFollowers] = useState({});
   const [totalReachNum, setTotalReachNum] = useState(0);
 
-  // Mirror EpkHeader: fetch followers whenever the filmmaker data changes
   useEffect(() => {
     const filmakerId = filmmakerInfo?._id;
     if (!filmakerId) return;
@@ -47,7 +46,7 @@ export default function FilmmakerSocial({ filmmakerInfo, isEditMode, onChange })
       </h2>
 
       <div className="tw-mb-8">
-        <SocialMedia socials={socialMediaData} totalReachNum={totalReachNum} />
+        <SocialMedia socials={socialMediaData} totalReachNum={totalReachNum} split />
       </div>
 
       {isEditMode && (
@@ -62,15 +61,21 @@ export default function FilmmakerSocial({ filmmakerInfo, isEditMode, onChange })
                 value={filmmakerInfo?.[urlField] || ''}
                 onChange={(e) => onChange(urlField, e.target.value)}
                 placeholder={`https://${key}.com/yourprofile`}
-                className="tw-bg-[#1E0039] tw-border tw-border-[#5A3F49] focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-3 tw-py-2.5 tw-text-white tw-text-sm tw-outline-none tw-transition-colors"
+                className={`tw-bg-[#1E0039] tw-border ${errors?.[urlField] ? 'tw-border-red-500' : 'tw-border-[#5A3F49]'} focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-3 tw-py-2.5 tw-text-white tw-text-sm tw-outline-none tw-transition-colors`}
               />
+              {errors?.[urlField] && (
+                <p className="tw-text-red-400 tw-text-xs tw-m-0 tw-mt-0.5">{errors[urlField]}</p>
+              )}
               <input
                 type="text"
                 value={filmmakerInfo?.[followersField] || ''}
                 onChange={(e) => onChange(followersField, e.target.value)}
                 placeholder="Follower count (e.g. 12500)"
-                className="tw-bg-[#1E0039] tw-border tw-border-[#5A3F49] focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-3 tw-py-2 tw-text-[#E2BDC9] tw-text-xs tw-outline-none tw-transition-colors"
+                className={`tw-bg-[#1E0039] tw-border ${errors?.[followersField] ? 'tw-border-red-500' : 'tw-border-[#5A3F49]'} focus:tw-border-[#FF43A7] tw-rounded-lg tw-px-3 tw-py-2 tw-text-[#E2BDC9] tw-text-xs tw-outline-none tw-transition-colors`}
               />
+              {errors?.[followersField] && (
+                <p className="tw-text-red-400 tw-text-xs tw-m-0 tw-mt-0.5">{errors[followersField]}</p>
+              )}
             </div>
           ))}
         </div>

--- a/client/src/pages/FilmMaker/Filmmaker.js
+++ b/client/src/pages/FilmMaker/Filmmaker.js
@@ -251,9 +251,10 @@ export default function Filmmaker(props) {
 
       {/* Social Media Total Audience Reach Section */}
       <div className="tw-mx-auto tw-my-8 tw-max-w-[100rem] tw-rounded-2xl tw-bg-[#1E0039] tw-p-6">
-        <SocialMedia 
-          socials={socialMediaData} 
+        <SocialMedia
+          socials={socialMediaData}
           totalReachNum={socialMediafollowerTotalNum}
+          split
         />
       </div>
 

--- a/client/src/pages/FilmMaker/FilmmakerPage.js
+++ b/client/src/pages/FilmMaker/FilmmakerPage.js
@@ -5,6 +5,7 @@ import http from '../../http-common';
 import { uploadSingleFile, getFepksByFilmmakerId } from '../../api/epks';
 
 import FilmmakerEditNavBar from '../../components/FilmmakerView/FilmmakerEditNavBar';
+import { validateFilmmakerDraft, ERROR_LABELS, firstErrorSection } from '../../utils/validateFilmmakerDraft';
 import FilmmakerHero from '../../components/FilmmakerView/FilmmakerHero/FilmmakerHero';
 import FilmmakerBio from '../../components/FilmmakerView/FilmmakerBio/FilmmakerBio';
 import FilmmakerSocial from '../../components/FilmmakerView/FilmmakerSocial/FilmmakerSocial';
@@ -119,9 +120,7 @@ export default function FilmmakerPage() {
   };
 
   const handleSaveAndExit = async () => {
-    const newErrors = {};
-    if (!draftFilmmaker?.firstName?.trim()) newErrors.firstName = true;
-    if (!draftFilmmaker?.lastName?.trim())  newErrors.lastName  = true;
+    const newErrors = validateFilmmakerDraft(draftFilmmaker);
 
     if (Object.keys(newErrors).length > 0) {
       setErrors(newErrors);
@@ -212,6 +211,7 @@ export default function FilmmakerPage() {
             filmmakerInfo={activeData}
             isEditMode={isEditMode}
             onChange={handleFieldChange}
+            errors={errors}
           />
         </div>
 
@@ -220,6 +220,7 @@ export default function FilmmakerPage() {
             filmmakerInfo={activeData}
             isEditMode={isEditMode}
             onChange={handleFieldChange}
+            errors={errors}
           />
         </div>
 
@@ -232,6 +233,7 @@ export default function FilmmakerPage() {
             filmmakerInfo={activeData}
             isEditMode={isEditMode}
             onChange={handleFieldChange}
+            errors={errors}
           />
         </div>
 
@@ -244,18 +246,18 @@ export default function FilmmakerPage() {
         <div className="tw-fixed tw-inset-0 tw-z-[1060] tw-flex tw-items-center tw-justify-center tw-bg-[#0a0014]/90 tw-backdrop-blur-sm tw-p-4">
           <div className="tw-bg-[#280D41] tw-border tw-border-red-500/50 tw-rounded-2xl tw-p-6 md:tw-p-8 tw-max-w-md tw-w-full tw-shadow-[0_20px_50px_rgba(239,68,68,0.2)]">
             <h3 className="tw-text-white tw-text-xl md:tw-text-2xl tw-font-bold tw-mb-4">
-              Missing Information
+              Fix the following before saving
             </h3>
-            <p className="tw-text-[#E2BDC9] tw-text-sm tw-mb-6 tw-leading-relaxed">
-              Please complete the following required fields before saving your profile:
-            </p>
-            <ul className="tw-list-disc tw-list-inside tw-text-white tw-font-bold tw-text-sm tw-mb-8 tw-space-y-2 tw-bg-[#1E0039] tw-p-4 tw-rounded-xl">
-              {errors.firstName && <li className="tw-text-red-400">First Name</li>}
-              {errors.lastName  && <li className="tw-text-red-400">Last Name</li>}
+            <ul className="tw-list-none tw-p-0 tw-m-0 tw-mb-8 tw-space-y-2 tw-bg-[#1E0039] tw-p-4 tw-rounded-xl">
+              {Object.entries(errors).map(([field, message]) => (
+                <li key={field} className="tw-text-red-400 tw-text-sm">
+                  <span className="tw-font-bold">{ERROR_LABELS[field] ?? field}:</span> {message}
+                </li>
+              ))}
             </ul>
             <div className="tw-flex tw-justify-end">
               <button
-                onClick={() => { setShowValidationModal(false); scrollToSection('hero'); }}
+                onClick={() => { setShowValidationModal(false); scrollToSection(firstErrorSection(errors)); }}
                 className="tw-px-6 tw-py-2.5 tw-bg-red-500 hover:tw-bg-red-600 tw-rounded-lg tw-text-white tw-font-bold tw-text-sm tw-uppercase tw-tracking-widest tw-border-none tw-shadow-[0_0_15px_rgba(239,68,68,0.4)] tw-transition-colors tw-cursor-pointer"
               >
                 Review Fields

--- a/client/src/utils/validateFilmmakerDraft.js
+++ b/client/src/utils/validateFilmmakerDraft.js
@@ -1,0 +1,111 @@
+const URL_RE = /^(https?:\/\/|www\.)\S+/i;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_RE = /^[0-9\s+\-().]+$/;
+
+const SOCIAL_URL_FIELDS = [
+  'facebook_url', 'instagram_url', 'twitter_url',
+  'tiktok_url', 'youtube_url', 'linkedin_url',
+];
+
+const FOLLOWER_FIELDS = [
+  'facebook_followers', 'instagram_followers', 'twitter_followers',
+  'tiktok_followers', 'youtube_subs', 'linkedin_followers',
+];
+
+export function validateFilmmakerDraft(draft) {
+  const errors = {};
+
+  // ── Hero ─────────────────────────────────────────────────────────────────
+  const firstName = draft?.firstName?.trim() || '';
+  const lastName  = draft?.lastName?.trim()  || '';
+
+  if (!firstName)
+    errors.firstName = 'First name is required';
+  else if (firstName.length < 2 || firstName.length > 30)
+    errors.firstName = 'First name must be 2–30 characters';
+
+  if (!lastName)
+    errors.lastName = 'Last name is required';
+  else if (lastName.length < 2 || lastName.length > 30)
+    errors.lastName = 'Last name must be 2–30 characters';
+
+  if (draft?.city && draft.city.length > 50)
+    errors.city = 'City must be under 50 characters';
+
+  if (draft?.country && draft.country.length > 50)
+    errors.country = 'Country must be under 50 characters';
+
+  // ── Bio ──────────────────────────────────────────────────────────────────
+  if (draft?.aboutMe && draft.aboutMe.length > 2000)
+    errors.aboutMe = `Biography is too long (${draft.aboutMe.length}/2000)`;
+
+  // ── Social URLs ──────────────────────────────────────────────────────────
+  for (const field of SOCIAL_URL_FIELDS) {
+    const val = draft?.[field]?.trim();
+    if (val && !URL_RE.test(val))
+      errors[field] = 'Enter a valid URL (e.g. https://... or www....)';
+  }
+
+  // ── Follower counts ──────────────────────────────────────────────────────
+  for (const field of FOLLOWER_FIELDS) {
+    const val = draft?.[field];
+    if (val !== '' && val !== null && val !== undefined) {
+      const num = Number(String(val).replace(/,/g, ''));
+      if (isNaN(num) || num < 0) errors[field] = 'Must be a positive number';
+    }
+  }
+
+  // ── Contact ──────────────────────────────────────────────────────────────
+  const email   = draft?.email?.trim();
+  const website = draft?.website?.trim();
+  const phone   = draft?.phone?.trim();
+
+  if (email && !EMAIL_RE.test(email))
+    errors.email = 'Must be a valid email address';
+
+  if (website && !URL_RE.test(website))
+    errors.website = 'Enter a valid URL (e.g. https://... or www....)';
+
+  if (phone && !PHONE_RE.test(phone))
+    errors.phone = 'Phone can only contain digits, spaces, +, -, and ()';
+
+  return errors;
+}
+
+export const ERROR_LABELS = {
+  firstName:            'First Name',
+  lastName:             'Last Name',
+  city:                 'City',
+  country:              'Country',
+  aboutMe:              'Biography',
+  facebook_url:         'Facebook URL',
+  instagram_url:        'Instagram URL',
+  twitter_url:          'Twitter/X URL',
+  tiktok_url:           'TikTok URL',
+  youtube_url:          'YouTube URL',
+  linkedin_url:         'LinkedIn URL',
+  facebook_followers:   'Facebook Followers',
+  instagram_followers:  'Instagram Followers',
+  twitter_followers:    'Twitter/X Followers',
+  tiktok_followers:     'TikTok Followers',
+  youtube_subs:         'YouTube Subscribers',
+  linkedin_followers:   'LinkedIn Followers',
+  email:                'Email',
+  website:              'Website',
+  phone:                'Phone',
+};
+
+export const SECTION_FIELDS = {
+  hero:    ['firstName', 'lastName', 'city', 'country'],
+  bio:     ['aboutMe'],
+  social:  ['facebook_url', 'instagram_url', 'twitter_url', 'tiktok_url', 'youtube_url', 'linkedin_url',
+            'facebook_followers', 'instagram_followers', 'twitter_followers', 'tiktok_followers', 'youtube_subs', 'linkedin_followers'],
+  contact: ['email', 'website', 'phone'],
+};
+
+export function firstErrorSection(errors) {
+  for (const [section, fields] of Object.entries(SECTION_FIELDS)) {
+    if (fields.some((f) => errors[f])) return section;
+  }
+  return 'hero';
+}


### PR DESCRIPTION
## Summary

**Social Media reach redesign**
- Replaced the flat inline "Total Audience Reach: X" stat with a styled gradient card (pink gradient number, glowing border)
- Added `split` layout to `SocialMedia`: card on the left, divider, platform icons on the right applied to all callsites
- Added `coverLayout` variant for the EPK page: card pins to the poster column, icons align to the banner column, matching the `EpkCover` grid
- Mobile on all `split` instances: shows only the reach card; tapping expands the full platform icon list inline; tapping outside collapses it

**Filmmaker profile form validation**
- Added `validateFilmmakerDraft.js` utility: validates first/last name (required, 2–30 chars), city/country (max 50), bio (max 2000), social URLs, follower counts, email, website, and phone
- Inline error display wired into `FilmmakerBio`, `FilmmakerContact`, `FilmmakerHero`, and `FilmmakerSocial`
- Save is blocked until all errors are resolved; validation modal lists all errors with human-readable labels and scrolls to the first failing section on dismiss

**FilmmakerHero mobile layout fix**
- Profile photo and name/role/location were misaligned on mobile (name appeared south-east of the photo)
- Replaced absolute-positioned photo + sibling name div with a single flex row; photo bleeds into the banner via negative margin-top; both elements are now vertically centered on all screen sizes