### PR TITLE
feat: Profile & Analytics Improvements

### DIFF
--- a/client/src/components/EpkView/EpkHeader/SocialMedia.js
+++ b/client/src/components/EpkView/EpkHeader/SocialMedia.js
@@ -178,6 +178,13 @@ export default function SocialMedia({ socials, totalReachNum, viewCount, feature
                     textClass="tw-text-[10px] md:tw-text-xs tw-font-bold tw-mt-2"
                   />
                 ))}
+                <SocialMediaIcon
+                  platform="views"
+                  followerNum={viewCount}
+                  containerClass="tw-flex tw-flex-col tw-items-center tw-justify-center tw-w-[50px] md:tw-w-[60px]"
+                  iconClass="tw-h-6 tw-w-6 md:tw-h-7 md:tw-w-7"
+                  textClass="tw-text-[10px] md:tw-text-xs tw-font-bold tw-mt-2"
+                />
               </div>
             </div>
           )}
@@ -217,22 +224,16 @@ export default function SocialMedia({ socials, totalReachNum, viewCount, feature
                     textClass="tw-text-[10px] md:tw-text-xs tw-font-bold tw-mt-2"
                   />
                 ))}
+                <SocialMediaIcon
+                  platform="views"
+                  followerNum={viewCount}
+                  containerClass="tw-flex tw-flex-col tw-items-center tw-justify-center tw-w-[50px] md:tw-w-[60px]"
+                  iconClass="tw-h-6 tw-w-6 md:tw-h-7 md:tw-w-7"
+                  textClass="tw-text-[10px] md:tw-text-xs tw-font-bold tw-mt-2"
+                />
               </div>
             </div>
           )}
-        </div>
-      )}
-
-      {/* VIEWS STAT */}
-      {!featured && (
-        <div className="tw-flex tw-flex-row tw-items-center tw-justify-center tw-gap-2">
-          <SocialMediaIcon
-            platform="views"
-            followerNum={viewCount}
-            containerClass="tw-flex tw-flex-row tw-items-center tw-gap-1.5"
-            iconClass="tw-h-6 tw-w-6 md:tw-h-8 md:tw-w-8"
-            textClass="tw-text-base md:tw-text-xl tw-font-semibold"
-          />
         </div>
       )}
 

--- a/client/src/components/FilmmakerView/FilmmakerHero/FilmmakerHero.js
+++ b/client/src/components/FilmmakerView/FilmmakerHero/FilmmakerHero.js
@@ -56,26 +56,26 @@ export default function FilmmakerHero({ filmmakerInfo, isEditMode, onChange, err
 
   return (
     <>
-      <div className="tw-w-full">
+      <div className="tw-w-full tw-max-w-[1280px] tw-mx-auto">
 
         {/* ── Banner ── */}
-        <div className="tw-relative tw-w-full tw-h-[280px] md:tw-h-[360px] tw-overflow-hidden tw-bg-[#280D41]">
+        <div className="tw-relative tw-w-full tw-h-[280px] md:tw-h-[360px] tw-overflow-hidden tw-bg-[#280D41] tw-rounded-2xl tw-border tw-border-[#FF43A7]/50">
           {isBannerVideo ? (
             <video
               src={bannerSrc}
               muted
               playsInline
               preload="metadata"
-              className="tw-w-full tw-h-full tw-object-cover tw-opacity-60"
+              className="tw-w-full tw-h-full tw-object-cover"
             />
           ) : (
             <img
               src={bannerSrc}
               alt="Filmmaker banner"
-              className="tw-w-full tw-h-full tw-object-cover tw-opacity-60"
+              className="tw-w-full tw-h-full tw-object-cover"
             />
           )}
-          <div className="tw-absolute tw-inset-0 tw-bg-gradient-to-t tw-from-[#1E0039] tw-via-transparent tw-to-transparent" />
+          <div className="tw-absolute tw-inset-0 tw-bg-black/25" />
 
           {/* Play button — only on video banners when not editing */}
           {isBannerVideo && !isEditMode && (

--- a/client/src/components/UserView/UserHeader/UserHeader.js
+++ b/client/src/components/UserView/UserHeader/UserHeader.js
@@ -41,10 +41,10 @@ export default function UserHeader({ data, setGlobalTotalReach }) {
   return (
     <div className="tw-flex tw-w-full tw-flex-col tw-items-center">
       <div className="tw-flex tw-w-full tw-items-center tw-justify-evenly tw-gap-5 tw-py-4">
-        <SocialMedia 
-          socials={socialMediaData} 
+        <SocialMedia
+          socials={socialMediaData}
           totalReachNum={socialMediafollowerTotalNum}
-          viewCount={data?.viewCount || 0}
+          viewCount={data?.profileViews || 0}
         />
       </div>
     </div>

--- a/client/src/pages/User/ProfileViewPage.js
+++ b/client/src/pages/User/ProfileViewPage.js
@@ -340,7 +340,25 @@ useEffect(() => {
       if (finalDraft.new_banner_file) {
         const bannerKey = await uploadSingleFile(finalDraft.new_banner_file, user?.token);
         finalDraft.banners = [{ url: bannerKey, is_thumbnail: true }];
+
+        if (finalDraft.new_banner_type === 'video') {
+          if (!finalDraft.video_gallery) {
+            finalDraft.video_gallery = { reels: [], media: [], behind: [], premieres: [] };
+          }
+          const alreadyInReels = (finalDraft.video_gallery.reels || []).some(r => r.url === bannerKey);
+          if (!alreadyInReels) {
+            finalDraft.video_gallery = {
+              ...finalDraft.video_gallery,
+              reels: [
+                ...(finalDraft.video_gallery.reels || []),
+                { url: bannerKey, title: '', thumbnail: '', isMain: true },
+              ],
+            };
+          }
+        }
+
         delete finalDraft.new_banner_file;
+        delete finalDraft.new_banner_type;
       }
 
       // 7. API Call
@@ -416,6 +434,16 @@ useEffect(() => {
           )}
           </div>
 
+          {isEditMode && (
+            <div ref={socialsRef}>
+              <UserSocials
+                userInfo={activeData}
+                isEditMode={isEditMode}
+                onChange={handleFieldChange}
+              />
+            </div>
+          )}
+
           <div ref={summaryRef}>
           <UserSummary 
             data={activeData}
@@ -474,15 +502,6 @@ useEffect(() => {
             isEditMode={isEditMode} 
             onChange={handleFieldChange} 
             />
-          </div>
-          <div>
-            {isEditMode && (
-              <div ref={socialsRef}> 
-                <UserSocials data={activeData}
-                isEditMode={isEditMode}            
-                onChange={handleFieldChange} />
-              </div>
-            )}
           </div>
           {showLoginModal && <LoginModal close={handleClose} open={handleShow} setRefresh={setRefresh}/>}
           {showMessageModal && (

--- a/server/controllers/analytics.js
+++ b/server/controllers/analytics.js
@@ -43,8 +43,7 @@ export const trackUniversalView = async (req, res) => {
       // THE SWITCH: Update the correct profile based on the Type
       if (targetType === 'EPK') {
         await fepk.findByIdAndUpdate(targetId, { $inc: { viewCount: 1 } });
-        //TODO: add view tracking for others profile types if needed
-      } else if (targetType === 'Actor' || targetType === 'Filmmaker') {
+      } else {
         await User.findByIdAndUpdate(targetId, { $inc: { profileViews: 1 } });
       }
       //  Drop the 24-hour cookie on user browser


### PR DESCRIPTION
# PR: Profile & Analytics Improvements

## 1. FilmmakerHero: width, overlay, and border

**Problem:** The FilmmakerHero banner was wider than all other page sections, the gradient overlay darkened the media too aggressively, and there was no visual boundary on the banner.

**Fix:**
- Added `tw-max-w-[1280px] tw-mx-auto` to match the UserHero container width.
- Replaced the gradient overlay with a flat `tw-bg-black/25` tint.
- Added a pink border (`tw-border-[#FF43A7]/50`) to the banner container.

**Files:** `client/src/components/FilmmakerView/FilmmakerHero/FilmmakerHero.js`

## 2. FilmmakerHero video banner: sync to Video Library

**Problem:** Uploading a video as the hero banner saved it to `banners` only. It never appeared in the Video Library (`video_gallery.reels`), so users had to upload the same video twice.

**Fix:** When `new_banner_type === 'video'`, the save handler now also pushes the uploaded key into `video_gallery.reels` (with a duplicate check) so it appears in the library automatically.

**Files:** `client/src/pages/User/ProfileViewPage.js`

## 3. UserSocials: move editor to top of page

**Problem:** In edit mode, the Social Media & Reach editor (UserSocials) was rendered at the bottom of the page — after photos, videos, and filmography — while the reach display sat at the top. The editor and display were visually disconnected.

**Fix:** Moved UserSocials to render immediately after the hero block so the editor is co-located with the display.

**Bonus fix:** The component was being passed `data={activeData}` but its prop is named `userInfo`, so all URL inputs and follower count fields were reading `undefined`. Fixed the prop name.

**Files:** `client/src/pages/User/ProfileViewPage.js`

## 4. Profile view count: field name fix and role coverage

**Problem 1:** `UserHeader` was reading `data?.viewCount` (the EPK field name) instead of `data?.profileViews` (the User field name), so the view count always displayed as 0.

**Problem 2:** The analytics controller only incremented `profileViews` for `targetType === 'Actor'` or `'Filmmaker'`. Users with any other role (Director, Producer, Sales Agent, etc.) never had their views counted.

**Fix:** Corrected the field name in `UserHeader`. Expanded the analytics controller so any non-EPK target type increments `profileViews`.

**Files:** `client/src/components/UserView/UserHeader/UserHeader.js`, `server/controllers/analytics.js`

## 5. SocialMedia: view count icon moved into dropdown

**Problem:** The views (eye) icon sat as a standalone element next to the Total Audience Reach counter, separate from the social platform icons in the expandable dropdown.

**Fix:** Moved the views icon inside both dropdown grids (featured and non-featured variants) alongside the other platform icons. Removed the `!!viewCount` guard so it renders even when the count is 0.

**Files:** `client/src/components/EpkView/EpkHeader/SocialMedia.js`
