### PR TITLE
feat: fix duplicate socials, add generic ErrorPage & add toast feedback on EPK and profile saves

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React, { useState } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import './styles/tailwind.css';
 
 import MainLayout from './layouts/MainLayout';
@@ -34,6 +34,7 @@ import AdminDashboardEPKs from './pages/AdminDashboard/EPKsPage';
 
 import AuthRoutes from './utils/AuthRoutes';
 import AccessDeniedPage from './pages/AccessDeniedPage';
+import ErrorPage from './pages/ErrorPage';
 import { FepkContext } from './context/FepkContext';
 import CatalogPage from './pages/CatalogPage.js';
 import EpkViewPage from './pages/EpkViewPage';
@@ -121,7 +122,7 @@ function App() {
           />
 
         </Route>
-        <Route path="*" element={<Navigate to="/" />} />
+        <Route path="*" element={<ErrorPage code={404} />} />
 
         <Route element={<EditFepkLayout title="Edit EPK" />} >
           <Route path="editFepk/:id" element={<FepkEditDashboard />} />

--- a/client/src/components/UserView/UserSocials/UserSocials.js
+++ b/client/src/components/UserView/UserSocials/UserSocials.js
@@ -44,10 +44,10 @@ export default function UserSocials({ userInfo, isEditMode, onChange }) {
         Social Media &amp; Reach
       </h2>
 
-      {/* The Display View (Always visible) */}
-      <div className={isEditMode ? "tw-mb-12" : "tw-mb-0"}>
+      {/* The Display View (hidden in edit mode — UserHeader already shows it at the top) */}
+      {!isEditMode && (
         <SocialMedia socials={socialMediaData} totalReachNum={totalReachNum} split />
-      </div>
+      )}
 
       {/* The Edit View (Conditional) */}
       {isEditMode && (

--- a/client/src/components/common/ErrorBoundary.js
+++ b/client/src/components/common/ErrorBoundary.js
@@ -1,0 +1,24 @@
+import React from "react";
+import ErrorPage from "../../pages/ErrorPage";
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("Uncaught error:", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorPage code={500} />;
+    }
+    return this.props.children;
+  }
+}

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -14,6 +14,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import reducers from "./reducers";
 
 import App from "./App";
+import ErrorBoundary from "./components/common/ErrorBoundary";
 import ChatProvider from "./context/ChatProvider";
 import { NotificationProvider } from "./context/NotificationContext";
 import { SocketProvider } from "./context/SocketProvider";
@@ -46,11 +47,13 @@ root.render(
     <PersistGate loading={null} persistor={persistor}>
       <SocketProvider>
         <BrowserRouter>
-          <ChatProvider>
-            <NotificationProvider>
-              <App />
-            </NotificationProvider>
-          </ChatProvider>
+          <ErrorBoundary>
+            <ChatProvider>
+              <NotificationProvider>
+                <App />
+              </NotificationProvider>
+            </ChatProvider>
+          </ErrorBoundary>
         </BrowserRouter>
       </SocketProvider>
     </PersistGate>

--- a/client/src/pages/AccessDeniedPage.js
+++ b/client/src/pages/AccessDeniedPage.js
@@ -1,30 +1,6 @@
 import React from "react";
-import {useTranslation} from 'react-i18next';
-import { Link } from "react-router-dom";
+import ErrorPage from "./ErrorPage";
 
 export default function AccessDeniedPage() {
-  const { t } = useTranslation();
-  return (
-    <div className="tw-grid tw-min-h-full tw-place-items-center tw-bg-white tw-px-6 tw-py-24 sm:tw-py-32 lg:tw-px-8">
-      <div className="tw-text-center">
-        <p className="tw-text-base tw-font-semibold tw-text-indigo-600">403</p>
-        <h1 className="tw-mt-4 tw-text-3xl tw-font-bold tw-tracking-tight tw-text-gray-900 sm:tw-text-5xl">
-          {t("Access denied")}
-        </h1>
-        <p className="tw-mt-6 tw-text-base tw-leading-7 tw-text-gray-600">
-        {t("Sorry, you need to sign in to get access to this page.")}
-        </p>
-        <div className="tw-mt-10 tw-flex tw-items-center tw-justify-center tw-gap-x-6">
-          <Link to="/login"
-            className="tw-rounded-md tw-bg-indigo-600 tw-px-3.5 tw-py-2.5 tw-text-sm tw-font-semibold tw-text-white tw-shadow-sm hover:tw-bg-indigo-500 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-indigo-600"
-          >
-            {t("Sign in")}
-          </Link>
-          <Link to="/" className="tw-text-sm tw-font-semibold tw-text-gray-900">
-          {t("Go back home")} <span aria-hidden="true">&rarr;</span>
-          </Link>
-        </div>
-      </div>
-    </div>
-  );
+  return <ErrorPage code={403} />;
 }

--- a/client/src/pages/EpkViewPage.js
+++ b/client/src/pages/EpkViewPage.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars */
 import React, { useState, useEffect, useRef } from 'react';
 import { useParams, useLocation, useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import EpkHeader from '../components/EpkView/EpkHeader/EpkHeader';
 import EpkCover from '../components/EpkView/EpkCover/EpkCover';
 import EpkSocialAction from '../components/EpkView/EpkSocialAction/EpkSocialAction';
@@ -321,14 +322,15 @@ function EpkViewPage() {
       }
       
       const freshEpkData = await getFepksById(epkInfo._id);
-      setEpkInfo(freshEpkData); 
+      setEpkInfo(freshEpkData);
       setDraftEpk(null);
-      setIsEditMode(false); 
+      setIsEditMode(false);
+      toast.success("EPK saved successfully!");
       navigate(`/epk/${epkInfo._id}`, { replace: true });
-      
+
     } catch (error) {
       console.error("Save process failed:", error);
-      alert("Failed to save changes. Please try again.");
+      toast.error("Failed to save changes. Please try again.");
     } finally {
       setIsSaving(false);
     }

--- a/client/src/pages/ErrorPage.js
+++ b/client/src/pages/ErrorPage.js
@@ -1,0 +1,60 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import Navbar from "../components/navbar/Navbar";
+
+const ERROR_CONFIG = {
+  403: {
+    title: "Access denied",
+    message: "Sorry, you need to sign in to get access to this page.",
+    primaryAction: { label: "Sign in", to: "/login" },
+    secondaryAction: { label: "Go back home", to: "/" },
+  },
+  404: {
+    title: "Page not found",
+    message: "Sorry, we couldn't find the page you're looking for.",
+    primaryAction: { label: "Go back home", to: "/" },
+  },
+  500: {
+    title: "Something went wrong",
+    message: "Sorry, an unexpected error occurred on our end.",
+    primaryAction: { label: "Go back home", to: "/" },
+  },
+};
+
+export default function ErrorPage({ code = 404, title, message }) {
+  const { t } = useTranslation();
+  const config = ERROR_CONFIG[code] ?? ERROR_CONFIG[500];
+  const resolvedTitle = title ?? config.title;
+  const resolvedMessage = message ?? config.message;
+
+  return (
+    <div className="tw-min-h-screen tw-bg-gradient-to-b tw-from-[#4b1a77] tw-to-[#1f0439] tw-flex tw-flex-col">
+      <Navbar className="tw-bg-gradient-to-b tw-from-[#4b1a77] tw-to-[#1f0439]" />
+      <div className="tw-flex-1 tw-grid tw-place-items-center tw-px-6 tw-py-24 sm:tw-py-32 lg:tw-px-8">
+        <div className="tw-text-center">
+          <p className="tw-text-base tw-font-semibold tw-text-purple-300">{code}</p>
+          <h1 className="tw-mt-4 tw-text-3xl tw-font-bold tw-tracking-tight tw-text-white sm:tw-text-5xl">
+            {t(resolvedTitle)}
+          </h1>
+          <p className="tw-mt-6 tw-text-base tw-leading-7 tw-text-purple-200">
+            {t(resolvedMessage)}
+          </p>
+          <div className="tw-mt-10 tw-flex tw-items-center tw-justify-center tw-gap-x-6">
+            <Link
+              to={config.primaryAction.to}
+              className="tw-rounded-md tw-bg-white tw-px-3.5 tw-py-2.5 tw-text-sm tw-font-semibold tw-text-[#4b1a77] tw-shadow-sm hover:tw-bg-purple-100 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-white"
+            >
+              {t(config.primaryAction.label)}
+            </Link>
+            {config.secondaryAction && (
+              <Link to={config.secondaryAction.to} className="tw-text-sm tw-font-semibold tw-text-white hover:tw-text-purple-200">
+                {t(config.secondaryAction.label)} <span aria-hidden="true">&rarr;</span>
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/User/ProfileViewPage.js
+++ b/client/src/pages/User/ProfileViewPage.js
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { useTranslation } from "react-i18next";
+import { toast } from 'react-toastify';
 
 import { getUserById, updateUserProfile, uploadSingleFile, deleteS3MediaBatch } from '../../api/users';
 import FilmmakerHero from '../../components/FilmmakerView/FilmmakerHero/FilmmakerHero';
@@ -377,11 +378,12 @@ useEffect(() => {
       setUserData(updatedUser);
       setDraftUser(null);
       setIsEditMode(false);
+      toast.success("Profile saved successfully!");
       navigate(`/user/${id}`, { replace: true });
 
     } catch (error) {
       console.error("Save process failed:", error);
-      alert("Error saving profile changes. Please try again.");
+      toast.error("Error saving profile changes. Please try again.");
     } finally {
       setIsSaving(false);
     }


### PR DESCRIPTION
## Summary

- Added a generic `ErrorPage` component (`pages/ErrorPage.js`) that handles 403, 404, and 500 codes with appropriate titles, messages, and CTAs
- Replaced the hardcoded `AccessDeniedPage` with a thin wrapper around `ErrorPage code={403}`
- Added an `ErrorBoundary` class component (`components/common/ErrorBoundary.js`) that catches React runtime crashes and renders `ErrorPage code={500}`
- Changed the `path="*"` catch-all in `App.js` from a silent redirect to `/` to rendering `ErrorPage code={404}`
- Wrapped `<App />` in `index.js` with `ErrorBoundary` (inside `BrowserRouter` so `Link` works on the 500 page)
- Wired up `toast.success` and `toast.error` to the save handlers in `EpkViewPage.js` and `ProfileViewPage.js`, replacing the silent redirect on success and the browser `alert()` on failure
- Fixed `UserSocials` rendering the social media widget twice in edit mode - `UserHeader` already renders it at the top of the page, so the duplicate inside `UserSocials` is now hidden when `isEditMode` is true

## How to test

**404** - Navigate to any unknown route (e.g. `/this-does-not-exist`). Should show "Page not found" with a "Go back home" button instead of silently redirecting.

**403** - Navigate to `/accessdenied`. Should show "Access denied" with "Sign in" and "Go back home" buttons.

**500** - Temporarily add `throw new Error("test")` inside any rendering component. The ErrorBoundary will catch it and show "Something went wrong." In dev mode, dismiss the React error overlay to see the page underneath.

**Toast on EPK save** - Edit an EPK and click Save. Should show a purple "EPK saved successfully!" toast at the top of the screen on success, or an error toast if the request fails.

**Toast on profile save** - Edit a user profile and click Save. Should show a purple "Profile saved successfully!" toast on success, or an error toast if the request fails.

**Social widget dedup** - Open a user profile in edit mode. The social media widget should appear once at the top (via `UserHeader`). The `UserSocials` section should show only the URL/follower count editor inputs, not a second widget.

## Notes

- `ErrorPage` accepts optional `title` and `message` props to override the defaults, so individual pages/API error handlers can reuse it with custom copy
- The 500 page only catches React render errors (JS crashes), not network-level 5XX API responses - those still need per-component handling